### PR TITLE
ABD-41: Don't automatically install or update python.

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
-
+set -eu
 
 if [ -z "$(which python3)" ];
 then
-    echo "install"
-    brew install python3
-else
-    echo "update"
-    brew upgrade python3
+    echo -e "\033[31mError: Expected the alias 'python3' to exist\033[0m"
+    echo -e "To install python3, run"
+    echo -e "    brew install python3"
+    exit 1
 fi
 
 pip3 install virtualenv


### PR DESCRIPTION
Make the startup script less aggressive, so that it does not automatically
install or update python on your machine.

Ideally, we would also verify the python version, but this requires too much
string parsing to be worth the time at this point.

Solo: @michaelwalker