### PR TITLE
ABD-41: Tests now run in a docker container with postgres running.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM python:latest
+RUN apt-get update && apt-get install -y postgresql postgresql-contrib sudo

--- a/build.jenkins
+++ b/build.jenkins
@@ -4,12 +4,12 @@ pipeline {
   stages {
     stage('Build') {
       agent {
-         docker { image 'python:3'
-                   args '-u root:sudo'}
+        dockerfile { additionalBuildArgs "--pull" }
       }
-      steps { sh './pre-commit.sh'
-              sh 'tar -zcvf verify-event-recorder-service.zip src/' }
-
+      steps {
+        sh './run-tests.sh'
+        sh 'tar -zcvf verify-event-recorder-service.zip src/'
+      }
     }
   }
 }

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
 
-pip3 install -r requirements.txt
-python3  -m unittest discover test/ "*_test.py"
+docker build -t event-emitter-image .
+docker create -t --name event-emitter-container event-emitter-image
+docker start event-emitter-container
+
+docker cp . event-emitter-container:/event-emitter
+docker exec -t --privileged --workdir /event-emitter event-emitter-container ./run-tests.sh
+
+docker stop event-emitter-container
+docker rm event-emitter-container

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -eu
+
+
+echo "starting PostgreSQL"
+service postgresql start
+sudo -u postgres psql --command "alter user postgres with encrypted password 'secretPassword';"
+
+echo "installing requirements"
+pip3 install -r requirements.txt
+
+echo "running tests"
+python3 -m unittest discover test/ "*_test.py"


### PR DESCRIPTION
We want to be able to run postgres locally in order to test that we can
correctly write to a Database. (Postgres is a good match for RDS running
Postgres)

Ideally, we would do this by spinning up a side-car docker container running
just postgres, and connect to that, but unfortunately side-car containers
are not secure in jenkins. We are therefore running postgres directly
within our python test-runner container.

Pre-commit now builds the container for us, and runs tests from within the
container, rather than running them directly on your local system.

Things that aren't yet ideal.
- it prints the output 'event-emitter-container' quite a lot
- it re-installs requirements.txt each time, which is a little slow.

Solo: @michaelwalker.