### PR TITLE
ABD-41: Fix not having sufficient permissions to start postgres in co…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,4 @@
 FROM python:latest
 RUN apt-get update && apt-get install -y postgresql postgresql-contrib sudo
+
+USER root

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -5,7 +5,7 @@ docker create -t --name event-emitter-container event-emitter-image
 docker start event-emitter-container
 
 docker cp . event-emitter-container:/event-emitter
-docker exec -t --privileged --workdir /event-emitter event-emitter-container ./run-tests.sh
+docker exec -t --workdir /event-emitter event-emitter-container ./run-tests.sh
 
 docker stop event-emitter-container
 docker rm event-emitter-container


### PR DESCRIPTION
…ntainer.

In Jenkins, we currently don't have permission to start postgres. Running
the command as sudo will (hopefully) elevate our permissions so that
we can.

Solo: @michaelwalker