### PR TITLE
ABD-41: Allow Jenkins agene to run as 'privileged'.

### DIFF
--- a/build.jenkins
+++ b/build.jenkins
@@ -4,7 +4,10 @@ pipeline {
   stages {
     stage('Build') {
       agent {
-        dockerfile { additionalBuildArgs "--pull" }
+        dockerfile {
+          additionalBuildArgs "--pull"
+          args "--privileged"
+        }
       }
       steps {
         sh './run-tests.sh'


### PR DESCRIPTION
This should ensure that it has permission to run all steps.

Solo: @michaelwalker.