### PR TITLE
ABD-41: Improve output of pre-comit.

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 docker build -t event-recorder-image .
-docker create -t --name event-recorder-container event-recorder-image
-docker start event-recorder-container
+echo "Created container: $(docker create -t --name event-recorder-container event-recorder-image)"
+echo "Started container: $(docker start event-recorder-container)"
 
 docker cp . event-recorder-container:/event-recorder
 docker exec -t --workdir /event-recorder event-recorder-container ./run-tests.sh
 
-docker stop event-recorder-container
-docker rm event-recorder-container
+echo "Stopped container: $(docker stop event-recorder-container)"
+echo "Removed container: $(docker rm event-recorder-container)"


### PR DESCRIPTION
Previously the docker commands just printed 'event-recorder-container' to
the output quite a lot.
This has now been changed to make it more descriptive. eg
'Stopped container: event-recorded-container'

Solo: @michaelwalker