### PR TITLE
BAU: Rename the virtualenv folder to env - and use it's pip.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea
 *.pyc
-event_recorder_virtualenv
+env

--- a/setup.sh
+++ b/setup.sh
@@ -10,5 +10,5 @@ then
 fi
 
 pip3 install virtualenv
-virtualenv --python=python3 event_recorder_virtualenv
-pip3 install -r requirements.txt
+virtualenv --python=python3 env
+env/bin/pip install -r requirements.txt


### PR DESCRIPTION
The convention is to just call this directory env, so lets switch to
follow that convention.

Also fix a bug where we used the global pip to install deps, rather than
the one supplied by virtualenv.

Solo: @michaelwalker