### PR TITLE
ABD-41: Enable devs to run postgres tests from their IDE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # verify-event-recorder-service
-This service is part of Verify's event recording system; its purpose is to read events from a queue and write them to a permanent datastore.
+This service is part of Verify's event recording system; its purpose is to read events from a queue and write them to a
+ permanent datastore.
+
+# Running tests against Postgres
+We run Postgres from inside a docker container.
+Running pre-commit will construct a docker container with Postgres and all our python dependencies, and then run all
+tests within that container (similar to the behaviour on the Jenkins build)
+
+If you want to run tests on your host machine (for example in your IDE), then you can also do that.
+- `setup.sh` will install python dependencies in a virtual environment
+- `start-docker.sh` will build and start a docker instance with Postgres that you can connect to from your host machine
+- `kill-docker.sh` will tear down your docker instance once you are done.
+
+With docker running, you should be able to connect to Postgres and run all tests from your host machine.

--- a/kill-docker.sh
+++ b/kill-docker.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Stopped container: $(docker stop event-recorder-container)"
+echo "Removed container: $(docker rm event-recorder-container)"

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,11 +1,5 @@
 #!/usr/bin/env bash
 
-docker build -t event-recorder-image .
-echo "Created container: $(docker create -t --name event-recorder-container event-recorder-image)"
-echo "Started container: $(docker start event-recorder-container)"
-
-docker cp . event-recorder-container:/event-recorder
+./start-docker.sh
 docker exec -t --workdir /event-recorder event-recorder-container ./run-tests.sh
-
-echo "Stopped container: $(docker stop event-recorder-container)"
-echo "Removed container: $(docker rm event-recorder-container)"
+./kill-docker.sh

--- a/start-docker.sh
+++ b/start-docker.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker build -t event-recorder-image .
+echo "Created container: $(docker create -t -p 5432:5432 --name event-recorder-container event-recorder-image)"
+echo "Started container: $(docker start event-recorder-container)"
+
+docker cp . event-recorder-container:/event-recorder


### PR DESCRIPTION
Previously these tests could only be run from within the docker container.
To make this possible, I have
- added `-p 5432:5432` to the docker build to expose the Postgres port to the host machine
- refactored pre-commit to have a 'start-docker' and 'stop-docker' scripts to make starting docker locally simple.
- added a section to the readme about this.

Solo: @michaelwalker