### PR TITLE
344: Fix decryption process issues

### DIFF
--- a/src/decryption.py
+++ b/src/decryption.py
@@ -4,13 +4,14 @@ from Crypto.Cipher import AES
 __SALT_LENGTH = 16
 
 
-def decrypt_message(encrypted_message, decryption_key):
+def decrypt_message(base64_encrypted_message, decryption_key):
     """
     encrypted_message expects a string in the format "<16 character plaintext salt><AES CBC encrypted message>"
     """
+    encrypted_message = base64.b64decode(base64_encrypted_message)
     salt = encrypted_message[:__SALT_LENGTH]
     cipher = AES.new(decryption_key, AES.MODE_CBC, IV=salt)
-    message = base64.b64decode(encrypted_message[__SALT_LENGTH:])
+    message = encrypted_message[__SALT_LENGTH:]
     return __pkcs5_unpad(cipher.decrypt(message).decode('utf-8'))
 
 

--- a/src/kms.py
+++ b/src/kms.py
@@ -1,6 +1,8 @@
 import boto3
+import base64
 
 def decrypt(encrypted_key):
     kms_client = boto3.client('kms')
-    response = kms_client.decrypt(CiphertextBlob=encrypted_key)
+    binary_data = base64.b64decode(encrypted_key)
+    response = kms_client.decrypt(CiphertextBlob=binary_data)
     return response['Plaintext']

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -1,5 +1,6 @@
 import os
 import boto3
+import base64
 import json
 import uuid
 import psycopg2
@@ -183,7 +184,7 @@ class EventHandlerTest(TestCase):
             KeyId=self.__key_id,
             Plaintext=ENCRYPTION_KEY,
         )
-        encrypted_encryption_key = response['CiphertextBlob']
+        encrypted_encryption_key = base64.b64encode(response['CiphertextBlob'])
         self.__s3_client.put_object(
             Bucket=bucket_name,
             Key=filename,

--- a/test/test_encrypter.py
+++ b/test/test_encrypter.py
@@ -20,4 +20,4 @@ def encrypt_string(plaintext, encryption_key):
     salt = str(uuid4())[:16]
     cipher = AES.new(encryption_key, AES.MODE_CBC, IV=salt)
     encrypted = cipher.encrypt(pad(plaintext, AES.block_size))
-    return salt + base64.b64encode(encrypted).decode('utf-8')
+    return base64.b64encode(bytes(salt, 'utf-8') + encrypted).decode('utf-8')


### PR DESCRIPTION
Update an event recorder system to decode base64 encrypted event encryption key before it attempts to decrypt the key.

Update the event recorder system to decode a whole base64 encrypted message before attempting to decrypt it using the event encryption key.

Authors: @adityapahuja