### PR TITLE
353: Store event's timestamp in datetime format

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1,6 +1,7 @@
 import json
 import psycopg2
 import os
+from datetime import datetime
 
 from psycopg2._psycopg import IntegrityError
 from psycopg2.errorcodes import UNIQUE_VIOLATION
@@ -34,7 +35,7 @@ def write_to_database(event, db_connection):
             """, [
                 event.event_id,
                 event.event_type,
-                event.timestamp,
+                datetime.fromtimestamp(int(event.timestamp) / 1e3),
                 json.dumps(event.details)
             ])
     except IntegrityError as integrityError:

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -16,7 +16,7 @@ from src.database import RunInTransaction
 from test.test_encrypter import encrypt_string
 
 EVENT_TYPE = 'session_event'
-TIMESTAMP = '2018-02-10 12:07:32'
+TIMESTAMP = 1518264452000 # '2018-02-10 12:07:32'
 SESSION_EVENT_TYPE = 'success'
 ENCRYPTION_KEY = b'sixteen byte key'
 
@@ -148,7 +148,7 @@ class EventHandlerTest(TestCase):
             self.assertIsNotNone(matching_records)
             self.assertEqual(matching_records[0], event_id)
             self.assertEqual(matching_records[1], EVENT_TYPE)
-            self.assertEqual(matching_records[2], datetime.strptime(TIMESTAMP, '%Y-%m-%d %H:%M:%S'))
+            self.assertEqual(matching_records[2], datetime.fromtimestamp(TIMESTAMP / 1e3))
             self.assertEqual(matching_records[3], {'sessionEventType': SESSION_EVENT_TYPE})
 
     def __setup_db_connection(self):


### PR DESCRIPTION
Currently, a database is rejecting event messages since their timestamp's format is integer and the database expects it to be in date time format. This change updates an event recorder system to convert the event message's timestamp from integer into datetime so that the message can then be stored in the database without errors.

Authors: @adityapahuja