### PR TITLE
Trello-4pAQRrkO: Replace PyCrypto

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,4 +3,3 @@ boto3==1.5.27
 moto==1.2.0
 testfixtures==5.4.0
 retrying==1.3.3
-pycrypto==2.6.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,3 +3,4 @@ boto3==1.5.27
 moto==1.2.0
 testfixtures==5.4.0
 retrying==1.3.3
+pycrypto==2.6.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,2 @@
 psycopg2-binary==2.7.4
-pycrypto==2.6.1
+cryptography==2.3.1

--- a/src/decryption.py
+++ b/src/decryption.py
@@ -1,5 +1,6 @@
 import base64
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
 
 __SALT_LENGTH = 16
 
@@ -10,9 +11,11 @@ def decrypt_message(base64_encrypted_message, decryption_key):
     """
     encrypted_message = base64.b64decode(base64_encrypted_message)
     salt = encrypted_message[:__SALT_LENGTH]
-    cipher = AES.new(decryption_key, AES.MODE_CBC, IV=salt)
+    cipher = Cipher(algorithms.AES(decryption_key), modes.CBC(salt), default_backend())
+    decrypter = cipher.decryptor()
     message = encrypted_message[__SALT_LENGTH:]
-    return __pkcs5_unpad(cipher.decrypt(message).decode('utf-8'))
+    decrypted_message = decrypter.update(message) + decrypter.finalize()
+    return __pkcs5_unpad(decrypted_message.decode('utf-8'))
 
 
 def __pkcs5_unpad(message):

--- a/test/decryption_test.py
+++ b/test/decryption_test.py
@@ -4,7 +4,7 @@ from test.test_encrypter import encrypt_string
 
 
 class EventHandlerTest(TestCase):
-    __key = 'sixteen byte key'
+    __key = b'sixteen byte key'
 
     def test_decrypts_message_with_full_final_block_padding(self):
         sixteen_char_message = '{ abcdefghijkl }'

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -7,7 +7,6 @@ import psycopg2
 from moto import mock_sqs, mock_s3, mock_kms
 from unittest import TestCase
 from datetime import datetime
-from Crypto.Cipher import AES
 from testfixtures import LogCapture
 from retrying import retry
 

--- a/test/test_encrypter.py
+++ b/test/test_encrypter.py
@@ -1,6 +1,7 @@
 import base64
 from uuid import uuid4
-from Crypto.Cipher import AES
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.backends import default_backend
 
 # padding from https://github.com/dlitz/pycrypto/blob/master/lib/Crypto/Util/Padding.py - in PyCrypto 2.7a1
 
@@ -18,6 +19,7 @@ def pad(data_to_pad, block_size, style='pkcs7'):
 
 def encrypt_string(plaintext, encryption_key):
     salt = str(uuid4())[:16]
-    cipher = AES.new(encryption_key, AES.MODE_CBC, IV=salt)
-    encrypted = cipher.encrypt(pad(plaintext, AES.block_size))
+    cipher = Cipher(algorithms.AES(encryption_key), modes.CBC(salt.encode()), backend=default_backend())
+    encryptor = cipher.encryptor()
+    encrypted = encryptor.update(pad(plaintext, 128).encode()) + encryptor.finalize()
     return base64.b64encode(bytes(salt, 'utf-8') + encrypted).decode('utf-8')


### PR DESCRIPTION
- This PR uses 2 commits to prove that the libraries are functionally the same (for our usage)
- The first only changes code in `src` and tests still pass
- Second does cleanup to remove dependency entirely