### PR TITLE
BAU: Shuffle some encryption

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -8,7 +8,9 @@ from psycopg2.errorcodes import UNIQUE_VIOLATION
 from logging import getLogger
 
 
-def create_db_connection():
+def create_db_connection(database_password):
+    if database_password:
+      return psycopg2.connect(os.environ['DB_CONNECTION_STRING'], password=database_password)
     return psycopg2.connect(os.environ['DB_CONNECTION_STRING'])
 
 

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -16,9 +16,13 @@ logging.basicConfig(level=logging.INFO)
 def store_queued_events(_, __):
     sqs_client = boto3.client('sqs')
     queue_url = os.environ['QUEUE_URL']
-    db_connection = create_db_connection()
     encrypted_decryption_key = fetch_decryption_key()
     decryption_key = decrypt(encrypted_decryption_key)
+
+    database_password = None
+    if 'ENCRYPTED_DATABASE_PASSWORD' in os.environ:
+      database_password = decrypt(os.environ['ENCRYPTED_DATABASE_PASSWORD'])
+    db_connection = create_db_connection(database_password)
 
     while True:
         message = fetch_single_message(sqs_client, queue_url)

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -11,12 +11,15 @@ from src.kms import decrypt
 
 logging.basicConfig(level=logging.INFO)
 
-
 # noinspection PyUnusedLocal
 def store_queued_events(_, __):
     sqs_client = boto3.client('sqs')
     queue_url = os.environ['QUEUE_URL']
-    encrypted_decryption_key = fetch_decryption_key()
+
+    if 'ENCRYPTION_KEY' in os.environ:
+      encrypted_decryption_key = os.environ['ENCRYPTION_KEY']
+    else:
+      encrypted_decryption_key = fetch_decryption_key()
     decryption_key = decrypt(encrypted_decryption_key)
 
     database_password = None

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -18,6 +18,7 @@ EVENT_TYPE = 'session_event'
 TIMESTAMP = 1518264452000 # '2018-02-10 12:07:32'
 SESSION_EVENT_TYPE = 'success'
 ENCRYPTION_KEY = b'sixteen byte key'
+DB_PASSWORD = 'secretPassword'
 
 @mock_sqs
 @mock_s3
@@ -29,7 +30,7 @@ class EventHandlerTest(TestCase):
     __queue_url = None
     __key_id = None
     db_connection = None
-    db_connection_string = "host='event-store' dbname='postgres' user='postgres' password='secretPassword'"
+    db_connection_string = "host='event-store' dbname='postgres' user='postgres'"
 
     @classmethod
     def setUpClass(cls):
@@ -43,7 +44,7 @@ class EventHandlerTest(TestCase):
     def setUp(self):
         setup_stub_aws_config()
         self.__setup_kms()
-        self.__setup_db_connection()
+        self.__setup_db_connection_string()
         self.__setup_sqs()
         self.__setup_s3()
 
@@ -63,6 +64,19 @@ class EventHandlerTest(TestCase):
         self.__assert_database_has_records(['sample-id-1', 'sample-id-2'])
         self.assertEqual(self.__number_of_visible_messages(), '0')
         self.assertEqual(self.__number_of_hidden_messages(), '0')
+
+    def test_writes_messages_to_db_with_password_from_env(self):
+        self.__setup_db_connection_string(True)
+        self.__encrypt_and_send_to_sqs(
+            [
+                create_event_string('sample-id-1'),
+                create_event_string('sample-id-2'),
+            ]
+        )
+
+        event_handler.store_queued_events(None, None)
+
+        self.__assert_database_has_records(['sample-id-1', 'sample-id-2'])
 
     def test_does_not_delete_invalid_messages(self):
         with LogCapture('event-recorder', propagate=False) as log_capture:
@@ -150,8 +164,12 @@ class EventHandlerTest(TestCase):
             self.assertEqual(matching_records[2], datetime.fromtimestamp(TIMESTAMP / 1e3))
             self.assertEqual(matching_records[3], {'sessionEventType': SESSION_EVENT_TYPE})
 
-    def __setup_db_connection(self):
-        os.environ['DB_CONNECTION_STRING'] = self.db_connection_string
+    def __setup_db_connection_string(self, password_in_env=False):
+        if password_in_env:
+          os.environ['DB_CONNECTION_STRING'] = self.db_connection_string
+          os.environ['ENCRYPTED_DATABASE_PASSWORD'] = self.__encrypt(DB_PASSWORD)
+        else:
+          os.environ['DB_CONNECTION_STRING'] = "{} password='{}'".format(self.db_connection_string, DB_PASSWORD)
 
     def __setup_sqs(self):
         self.__sqs_client = boto3.client('sqs')
@@ -176,14 +194,17 @@ class EventHandlerTest(TestCase):
         )
         self.__write_encryption_key_to_s3()
 
+    def __encrypt(self, content):
+        response = self.__kms_client.encrypt(
+            KeyId=self.__key_id,
+            Plaintext=content,
+        )
+        return base64.b64encode(response['CiphertextBlob'])
+
     def __write_encryption_key_to_s3(self):
         bucket_name = 'key-bucket'
         filename = 'encrypted-event-key.txt'
-        response = self.__kms_client.encrypt(
-            KeyId=self.__key_id,
-            Plaintext=ENCRYPTION_KEY,
-        )
-        encrypted_encryption_key = base64.b64encode(response['CiphertextBlob'])
+        encrypted_encryption_key = self.__encrypt(ENCRYPTION_KEY)
         self.__s3_client.put_object(
             Bucket=bucket_name,
             Key=filename,


### PR DESCRIPTION
- Added support to provide the encryption key in an encrypted env var instead
of from S3
- Added support for encrypting the database password instead of adding it in
plain text :scream: https://trello.com/c/CXREwQgE/157-encrypt-database-password-in-lambda