### PR TITLE
TRELLO-awtbKHKO: Write billing and fraud events to event storage

### DIFF
--- a/database-schema/V1__create_events_table.sql
+++ b/database-schema/V1__create_events_table.sql
@@ -1,6 +1,0 @@
-CREATE TABLE events (
-                    event_id TEXT NOT NULL PRIMARY KEY,
-                    event_type TEXT NOT NULL,
-                    timestamp TIMESTAMP NOT NULL,
-                    details JSONB NOT NULL
-                );

--- a/database-schema/create_audit_events_table.sql
+++ b/database-schema/create_audit_events_table.sql
@@ -1,0 +1,15 @@
+CREATE SCHEMA audit AUTHORIZATION postgres;
+
+CREATE TABLE audit.audit_events
+(
+    event_id             text COLLATE pg_catalog."default",
+    time_stamp           timestamp,
+    originating_service  text COLLATE pg_catalog."default",
+    session_id           text COLLATE pg_catalog."default",
+    event_type           text COLLATE pg_catalog."default",
+    details              jsonb,
+    PRIMARY KEY (event_id, time_stamp)
+)
+TABLESPACE pg_default;
+ALTER TABLE audit.audit_events OWNER to postgres;
+

--- a/database-schema/create_billing_and_fraud_events_table.sql
+++ b/database-schema/create_billing_and_fraud_events_table.sql
@@ -1,0 +1,28 @@
+CREATE SCHEMA billing AUTHORIZATION postgres;
+
+CREATE TABLE billing.billing_events
+(
+    time_stamp                   timestamp,
+    session_id                   text COLLATE pg_catalog."default",
+    hashed_persistent_id         text COLLATE pg_catalog."default",
+    request_id                   text COLLATE pg_catalog."default",
+    idp_entity_id                text COLLATE pg_catalog."default",
+    minimum_level_of_assurance   text COLLATE pg_catalog."default",
+    required_level_of_assurance  text COLLATE pg_catalog."default",
+    provided_level_of_assurance  text COLLATE pg_catalog."default"
+)
+TABLESPACE pg_default;
+ALTER TABLE billing.billing_events OWNER to postgres;
+
+CREATE TABLE billing.fraud_events
+(
+    time_stamp            timestamp,
+    session_id            text COLLATE pg_catalog."default",
+    hashed_persistent_id  text COLLATE pg_catalog."default",
+    request_id            text COLLATE pg_catalog."default",
+    entity_id             text COLLATE pg_catalog."default",
+    fraud_event_id        text COLLATE pg_catalog."default",
+    fraud_indicator       text COLLATE pg_catalog."default"
+)
+TABLESPACE pg_default;
+ALTER TABLE billing.fraud_events OWNER to postgres;

--- a/src/database.py
+++ b/src/database.py
@@ -26,18 +26,20 @@ class RunInTransaction:
         self.__connection.commit()
 
 
-def write_to_database(event, db_connection):
+def write_to_audit_database(event, db_connection):
     try:
         with RunInTransaction(db_connection) as cursor:
             cursor.execute("""
-                INSERT INTO events
-                (event_id, event_type, timestamp, details)
+                INSERT INTO audit.audit_events
+                (event_id, event_type, time_stamp, originating_service, session_id, details)
                 VALUES
-                (%s, %s, %s, %s);
+                (%s, %s, %s, %s, %s, %s);
             """, [
                 event.event_id,
                 event.event_type,
                 datetime.fromtimestamp(int(event.timestamp) / 1e3),
+                event.originating_service,
+                event.session_id,
                 json.dumps(event.details)
             ])
     except IntegrityError as integrityError:

--- a/src/event.py
+++ b/src/event.py
@@ -1,7 +1,9 @@
 class Event(object):
-    def __init__(self, event_id, timestamp, event_type, details):
+    def __init__(self, event_id, timestamp, event_type, originating_service, session_id, details):
         self.__event_id = event_id
         self.__timestamp = timestamp
+        self.__originating_service = originating_service
+        self.__session_id = session_id
         self.__event_type = event_type
         self.__details = details
 
@@ -16,6 +18,14 @@ class Event(object):
     @property
     def event_type(self):
         return self.__event_type
+
+    @property
+    def originating_service(self):
+        return self.__originating_service
+
+    @property
+    def session_id(self):
+        return self.__session_id
 
     @property
     def details(self):

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -2,7 +2,7 @@ import boto3
 import logging
 import os
 
-from src.database import create_db_connection, write_to_database
+from src.database import create_db_connection, write_to_audit_database
 from src.decryption import decrypt_message
 from src.event_mapper import event_from_json
 from src.s3 import fetch_decryption_key
@@ -37,7 +37,7 @@ def store_queued_events(_, __):
         try:
             decrypted_message = decrypt_message(message['Body'], decryption_key)
             event = event_from_json(decrypted_message)
-            write_to_database(event, db_connection)
+            write_to_audit_database(event, db_connection)
             delete_message(sqs_client, queue_url, message)
         except Exception as exception:
             logging.getLogger('event-recorder').exception('Failed to store message')

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -1,13 +1,15 @@
-import boto3
 import logging
 import os
 
-from src.database import create_db_connection, write_to_audit_database
+import boto3
+
+from src.database import create_db_connection, write_audit_event_to_audit_database, \
+    write_billing_event_to_billing_database, write_fraud_event_to_billing_database
 from src.decryption import decrypt_message
 from src.event_mapper import event_from_json
+from src.kms import decrypt
 from src.s3 import fetch_decryption_key
 from src.sqs import fetch_single_message, delete_message
-from src.kms import decrypt
 
 logging.basicConfig(level=logging.INFO)
 
@@ -37,7 +39,11 @@ def store_queued_events(_, __):
         try:
             decrypted_message = decrypt_message(message['Body'], decryption_key)
             event = event_from_json(decrypted_message)
-            write_to_audit_database(event, db_connection)
+            write_audit_event_to_audit_database(event, db_connection)
+            if event.event_type == 'session_event' and 'session_event_type' in event.details and event.details['session_event_type'] == 'idp_authn_succeeded':
+                write_billing_event_to_billing_database(event, db_connection)
+            if event.event_type == 'session_event' and 'session_event_type' in event.details and event.details['session_event_type'] == 'fraud_detected':
+                write_fraud_event_to_billing_database(event, db_connection)
             delete_message(sqs_client, queue_url, message)
         except Exception as exception:
             logging.getLogger('event-recorder').exception('Failed to store message')

--- a/src/event_mapper.py
+++ b/src/event_mapper.py
@@ -5,18 +5,22 @@ from src.event import Event
 EVENT_ID = 'eventId'
 EVENT_TYPE = 'eventType'
 TIMESTAMP = 'timestamp'
+ORIGINATING_SERVICE = 'originatingService'
+SESSION_ID = 'sessionId'
 DETAILS = 'details'
-REQUIRED_FIELDS = [EVENT_ID, EVENT_TYPE, TIMESTAMP, DETAILS]
+REQUIRED_FIELDS = [EVENT_ID, EVENT_TYPE, TIMESTAMP, ORIGINATING_SERVICE, SESSION_ID, DETAILS]
 
 
 def event_from_json(json_string):
     json_object = json.loads(json_string)
     __validate_json_object(json_object)
     return Event(
-        event_id=json_object[EVENT_ID],
-        timestamp=json_object[TIMESTAMP],
-        event_type=json_object[EVENT_TYPE],
-        details=json_object[DETAILS],
+        event_id = json_object[EVENT_ID],
+        timestamp= json_object[TIMESTAMP],
+        event_type = json_object[EVENT_TYPE],
+        originating_service = json_object[ORIGINATING_SERVICE],
+        session_id = json_object[SESSION_ID],
+        details = json_object[DETAILS],
     )
 
 

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -18,9 +18,18 @@ EVENT_TYPE = 'session_event'
 TIMESTAMP = 1518264452000 # '2018-02-10 12:07:32'
 SESSION_EVENT_TYPE = 'success'
 ORIGINATING_SERVICE = 'test service'
-SESSION_ID = 'test session id'
 ENCRYPTION_KEY = b'sixteen byte key'
 DB_PASSWORD = 'secretPassword'
+SESSION_EVENT_TYPE = 'idp_authn_succeeded'
+PID = '26b1e565bb63e7fc3c2ccf4e018f50b84953b02b89d523654034e24a4907d50c'
+REQUEST_ID = '_a217717d-ce3d-407c-88c1-d3d592b6db8c'
+IDP_ENTITY_ID = 'idp entity id'
+TRANSACTION_ENTITY_ID = 'transaction entity id'
+MINIMUM_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+PROVIDED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+REQUIRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+FRAUD_SESSION_EVENT_TYPE='fraud_detected'
+GPG45_STATUS='AA01'
 
 @mock_sqs
 @mock_s3
@@ -56,14 +65,36 @@ class EventHandlerTest(TestCase):
         self.__setup_s3()
         self.__encrypt_and_send_to_sqs(
             [
-                create_event_string('sample-id-1'),
-                create_event_string('sample-id-2'),
+                create_event_string('sample-id-1', 'session-id-1'),
+                create_event_string('sample-id-2', 'session-id-2'),
+                create_fraud_event_string('sample-id-3', 'session-id-3', 'fraud-event-id-1'),
+                create_fraud_event_string('sample-id-4', 'session-id-4', 'fraud-event-id-2'),
             ]
         )
 
         event_handler.store_queued_events(None, None)
 
-        self.__assert_database_has_records(['sample-id-1', 'sample-id-2'])
+        self.__assert_audit_database_has_billing_event_records([('sample-id-1', 'session-id-1'), ('sample-id-2', 'session-id-2')])
+        self.__assert_audit_database_has_fraud_event_records([('sample-id-3', 'session-id-3', 'fraud-event-id-1'), ('sample-id-4', 'session-id-4', 'fraud-event-id-2')])
+        self.__assert_billing_database_has_billing_event_records(['session-id-1', 'session-id-2'])
+        self.__assert_billing_database_has_fraud_event_records([('session-id-3', 'fraud-event-id-1'), ('session-id-4', 'fraud-event-id-2')])
+        self.assertEqual(self.__number_of_visible_messages(), '0')
+        self.assertEqual(self.__number_of_hidden_messages(), '0')
+
+    def test_reads_fraud_events_from_queue(self):
+        self.__setup_s3()
+        self.__encrypt_and_send_to_sqs(
+            [
+                create_fraud_event_string('sample-id-1', 'session-id-1', 'fraud-event-id-1'),
+                create_fraud_event_string('sample-id-2', 'session-id-2', 'fraud-event-id-2'),
+            ]
+        )
+
+        event_handler.store_queued_events(None, None)
+
+        self.__assert_audit_database_has_fraud_event_records([('sample-id-1', 'session-id-1', 'fraud-event-id-1'), ('sample-id-2', 'session-id-2', 'fraud-event-id-2')])
+        self.__assert_database_has_no_billing_event_records
+        self.__assert_billing_database_has_fraud_event_records([('session-id-1', 'fraud-event-id-1'), ('session-id-2', 'fraud-event-id-2')])
         self.assertEqual(self.__number_of_visible_messages(), '0')
         self.assertEqual(self.__number_of_hidden_messages(), '0')
 
@@ -71,14 +102,14 @@ class EventHandlerTest(TestCase):
         os.environ['ENCRYPTION_KEY'] = self.__encrypt(ENCRYPTION_KEY)
         self.__encrypt_and_send_to_sqs(
             [
-                create_event_string('sample-id-1'),
-                create_event_string('sample-id-2'),
+                create_event_string('sample-id-1', 'session-id-1'),
+                create_event_string('sample-id-2', 'session-id-2'),
             ]
         )
 
         event_handler.store_queued_events(None, None)
 
-        self.__assert_database_has_records(['sample-id-1', 'sample-id-2'])
+        self.__assert_audit_database_has_billing_event_records([('sample-id-1', 'session-id-1'), ('sample-id-2', 'session-id-2')])
         self.assertEqual(self.__number_of_visible_messages(), '0')
         self.assertEqual(self.__number_of_hidden_messages(), '0')
 
@@ -87,14 +118,14 @@ class EventHandlerTest(TestCase):
         self.__setup_db_connection_string(True)
         self.__encrypt_and_send_to_sqs(
             [
-                create_event_string('sample-id-1'),
-                create_event_string('sample-id-2'),
+                create_event_string('sample-id-1', 'session-id-1'),
+                create_event_string('sample-id-2', 'session-id-2'),
             ]
         )
 
         event_handler.store_queued_events(None, None)
 
-        self.__assert_database_has_records(['sample-id-1', 'sample-id-2'])
+        self.__assert_audit_database_has_billing_event_records([('sample-id-1', 'session-id-1'), ('sample-id-2', 'session-id-2')])
 
     def test_does_not_delete_invalid_messages(self):
         self.__setup_s3()
@@ -102,13 +133,15 @@ class EventHandlerTest(TestCase):
             self.__encrypt_and_send_to_sqs(
                 [
                     'invalid event',
-                    create_event_string('sample-id-2'),
+                    create_event_string('sample-id-2', 'session-id-2'),
                 ]
             )
 
             event_handler.store_queued_events(None, None)
 
-            self.__assert_database_has_records(['sample-id-2'])
+            self.__assert_audit_database_has_billing_event_records([('sample-id-2', 'session-id-2')])
+            self.__assert_billing_database_has_billing_event_records(['session-id-2'])
+            self.__assert_database_has_no_fraud_event_records
             log_capture.check(
                 (
                     'event-recorder',
@@ -124,19 +157,21 @@ class EventHandlerTest(TestCase):
         with LogCapture('event-recorder', propagate=False) as log_capture:
             self.__encrypt_and_send_to_sqs(
                 [
-                    create_event_string('sample-id-1'),
-                    create_event_string('sample-id-1'),
+                    create_event_string('sample-id-1', 'session-id-1'),
+                    create_event_string('sample-id-1', 'session-id-1'),
                 ]
             )
 
             event_handler.store_queued_events(None, None)
 
-            self.__assert_database_has_records(['sample-id-1'])
+            self.__assert_audit_database_has_billing_event_records([('sample-id-1', 'session-id-1')])
+            self.__assert_billing_database_has_billing_event_records(['session-id-1'])
+            self.__assert_database_has_no_fraud_event_records
             log_capture.check(
                 (
                     'event-recorder',
                     'WARNING',
-                    'Failed to store message. The Event ID sample-id-1 already exists in the database'
+                    'Failed to store an audit event. The Event ID sample-id-1 already exists in the database'
                 )
             )
             self.assertEqual(self.__number_of_visible_messages(), '0')
@@ -168,33 +203,167 @@ class EventHandlerTest(TestCase):
         with RunInTransaction(self.db_connection) as cursor:
             cursor.execute("""
                 DELETE FROM audit.audit_events;
+                DELETE FROM billing.billing_events;
+                DELETE FROM billing.fraud_events;
             """)
 
-    def __assert_database_has_records(self, expected_event_ids):
-        for event_id in expected_event_ids:
+    def __assert_audit_database_has_billing_event_records(self, expected_events):
+        for event in expected_events:
             with RunInTransaction(self.db_connection) as cursor:
                 cursor.execute("""
                     SELECT
                         event_id,
-                        event_type,
                         time_stamp,
                         originating_service,
                         session_id,
-                        details
+                        event_type,
+                        details->>'session_event_type',
+                        details->>'pid',
+                        details->>'request_id',
+                        details->>'idp_entity_id',
+                        details->>'transaction_entity_id',
+                        details->>'minimum_level_of_assurance',
+                        details->>'provided_level_of_assurance',
+                        details->>'required_level_of_assurance'
                     FROM
                         audit.audit_events
                     WHERE
                         event_id = %s;
-                """, [event_id])
+                """, [event[0]])
                 matching_records = cursor.fetchone()
 
             self.assertIsNotNone(matching_records)
-            self.assertEqual(matching_records[0], event_id)
-            self.assertEqual(matching_records[1], EVENT_TYPE)
-            self.assertEqual(matching_records[2], datetime.fromtimestamp(TIMESTAMP / 1e3))
-            self.assertEqual(matching_records[3], ORIGINATING_SERVICE)
-            self.assertEqual(matching_records[4], SESSION_ID)
-            self.assertEqual(matching_records[5], {'sessionEventType': SESSION_EVENT_TYPE})
+            self.assertEqual(matching_records[0], event[0])
+            self.assertEqual(matching_records[1], datetime.fromtimestamp(TIMESTAMP / 1e3))
+            self.assertEqual(matching_records[2], ORIGINATING_SERVICE)
+            self.assertEqual(matching_records[3], event[1])
+            self.assertEqual(matching_records[4], EVENT_TYPE)
+            self.assertEqual(matching_records[5], SESSION_EVENT_TYPE)
+            self.assertEqual(matching_records[6], PID)
+            self.assertEqual(matching_records[7], REQUEST_ID)
+            self.assertEqual(matching_records[8], IDP_ENTITY_ID)
+            self.assertEqual(matching_records[9], TRANSACTION_ENTITY_ID)
+            self.assertEqual(matching_records[10], MINIMUM_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[11], PROVIDED_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[12], REQUIRED_LEVEL_OF_ASSURANCE)
+
+    def __assert_audit_database_has_fraud_event_records(self, expected_events):
+        for event in expected_events:
+            with RunInTransaction(self.db_connection) as cursor:
+                cursor.execute("""
+                    SELECT
+                        event_id,
+                        time_stamp,
+                        originating_service,
+                        session_id,
+                        event_type,
+                        details->>'session_event_type',
+                        details->>'pid',
+                        details->>'request_id',
+                        details->>'idp_entity_id',
+                        details->>'idp_fraud_event_id',
+                        details->>'gpg45_status'
+                    FROM
+                        audit.audit_events
+                    WHERE
+                        event_id = %s;
+                """, [event[0]])
+                matching_records = cursor.fetchone()
+
+            self.assertIsNotNone(matching_records)
+            self.assertEqual(matching_records[0], event[0])
+            self.assertEqual(matching_records[1], datetime.fromtimestamp(TIMESTAMP / 1e3))
+            self.assertEqual(matching_records[2], ORIGINATING_SERVICE)
+            self.assertEqual(matching_records[3], event[1])
+            self.assertEqual(matching_records[4], EVENT_TYPE)
+            self.assertEqual(matching_records[5], FRAUD_SESSION_EVENT_TYPE)
+            self.assertEqual(matching_records[6], PID)
+            self.assertEqual(matching_records[7], REQUEST_ID)
+            self.assertEqual(matching_records[8], IDP_ENTITY_ID)
+            self.assertEqual(matching_records[9], event[2])
+            self.assertEqual(matching_records[10], GPG45_STATUS)
+
+    def __assert_database_has_no_billing_event_records(self):
+        with RunInTransaction(self.db_connection) as cursor:
+            cursor.execute("""
+                SELECT
+                    *
+                FROM
+                    billing.billing_events;
+            """)
+            matching_records = cursor.fetchone()
+
+        self.assertIsNone(matching_records)
+
+    def __assert_billing_database_has_billing_event_records(self, expected_session_ids):
+        for session_id in expected_session_ids:
+            with RunInTransaction(self.db_connection) as cursor:
+                cursor.execute("""
+                    SELECT
+                        time_stamp,
+                        session_id,
+                        hashed_persistent_id,
+                        request_id,
+                        idp_entity_id,
+                        minimum_level_of_assurance,
+                        required_level_of_assurance,
+                        provided_level_of_assurance
+                    FROM
+                        billing.billing_events
+                    WHERE
+                        session_id = %s;
+                """, [session_id])
+                matching_records = cursor.fetchone()
+
+            self.assertIsNotNone(matching_records)
+            self.assertEqual(matching_records[0], datetime.fromtimestamp(TIMESTAMP / 1e3))
+            self.assertEqual(matching_records[1], session_id)
+            self.assertEqual(matching_records[2], PID)
+            self.assertEqual(matching_records[3], REQUEST_ID)
+            self.assertEqual(matching_records[4], IDP_ENTITY_ID)
+            self.assertEqual(matching_records[5], MINIMUM_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[6], PROVIDED_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[7], REQUIRED_LEVEL_OF_ASSURANCE)
+
+    def __assert_database_has_no_fraud_event_records(self):
+        with RunInTransaction(self.db_connection) as cursor:
+            cursor.execute("""
+                SELECT
+                    *
+                FROM
+                    billing.fraud_events;
+            """)
+            matching_records = cursor.fetchone()
+
+        self.assertIsNone(matching_records)
+
+    def __assert_billing_database_has_fraud_event_records(self, expected_fraud_events):
+        for fraud_event in expected_fraud_events:
+            with RunInTransaction(self.db_connection) as cursor:
+                cursor.execute("""
+                    SELECT
+                        time_stamp,
+                        session_id,
+                        hashed_persistent_id,
+                        request_id,
+                        entity_id,
+                        fraud_event_id,
+                        fraud_indicator
+                    FROM
+                        billing.fraud_events
+                    WHERE
+                        session_id = %s;
+                """, [fraud_event[0]])
+                matching_records = cursor.fetchone()
+
+            self.assertIsNotNone(matching_records)
+            self.assertEqual(matching_records[0], datetime.fromtimestamp(TIMESTAMP / 1e3))
+            self.assertEqual(matching_records[1], fraud_event[0])
+            self.assertEqual(matching_records[2], PID)
+            self.assertEqual(matching_records[3], REQUEST_ID)
+            self.assertEqual(matching_records[4], IDP_ENTITY_ID)
+            self.assertEqual(matching_records[5], fraud_event[1])
+            self.assertEqual(matching_records[6], GPG45_STATUS)
 
     def __setup_db_connection_string(self, password_in_env=False):
         if password_in_env:
@@ -253,14 +422,39 @@ def setup_stub_aws_config():
     }
 
 
-def create_event_string(event_id):
+def create_event_string(event_id, session_id):
     return json.dumps({
         'eventId': event_id,
         'eventType': EVENT_TYPE,
         'timestamp': TIMESTAMP,
         'originatingService': ORIGINATING_SERVICE,
-        'sessionId': SESSION_ID,
+        'sessionId': session_id,
         'details': {
-            'sessionEventType': SESSION_EVENT_TYPE
+            'session_event_type': SESSION_EVENT_TYPE,
+            'pid': PID,
+            'request_id': REQUEST_ID,
+            'idp_entity_id': IDP_ENTITY_ID,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID,
+            'minimum_level_of_assurance': MINIMUM_LEVEL_OF_ASSURANCE,
+            'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
+            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
+        }
+    })
+
+
+def create_fraud_event_string(event_id, session_id, fraud_event_id):
+    return json.dumps({
+        'eventId': event_id,
+        'eventType': EVENT_TYPE,
+        'timestamp': TIMESTAMP,
+        'originatingService': ORIGINATING_SERVICE,
+        'sessionId': session_id,
+        'details': {
+            'session_event_type': FRAUD_SESSION_EVENT_TYPE,
+            'pid': PID,
+            'request_id': REQUEST_ID,
+            'idp_entity_id': IDP_ENTITY_ID,
+            'idp_fraud_event_id': fraud_event_id,
+            'gpg45_status': GPG45_STATUS
         }
     })

--- a/test/event_mapper_test.py
+++ b/test/event_mapper_test.py
@@ -7,6 +7,8 @@ from src.event_mapper import event_from_json
 EVENT_ID = '1234-abcd'
 EVENT_TYPE = 'session_event'
 TIMESTAMP = '2018-02-10:12:00:00'
+ORIGINATING_SERVICE = 'originating_service'
+SESSION_ID = 'session_id'
 SESSION_EVENT_TYPE = 'success'
 
 
@@ -20,6 +22,8 @@ class EventTest(TestCase):
         self.assertEqual(event.event_id, EVENT_ID)
         self.assertEqual(event.event_type, EVENT_TYPE)
         self.assertEqual(event.timestamp, TIMESTAMP)
+        self.assertEqual(event.originating_service, ORIGINATING_SERVICE)
+        self.assertEqual(event.session_id, SESSION_ID)
         self.assertEqual(event.details['sessionEventType'], SESSION_EVENT_TYPE)
 
     def test_ignores_additional_elements_in_json_string(self):
@@ -32,6 +36,8 @@ class EventTest(TestCase):
         self.assertEqual(event.event_id, EVENT_ID)
         self.assertEqual(event.event_type, EVENT_TYPE)
         self.assertEqual(event.timestamp, TIMESTAMP)
+        self.assertEqual(event.originating_service, ORIGINATING_SERVICE)
+        self.assertEqual(event.session_id, SESSION_ID)
         self.assertEqual(event.details['sessionEventType'], SESSION_EVENT_TYPE)
 
     def test_throws_validation_exception_if_required_element_is_missing(self):
@@ -39,6 +45,8 @@ class EventTest(TestCase):
             'eventId',
             'eventType',
             'timestamp',
+            'originatingService',
+            'sessionId',
             'details',
         ]
 
@@ -65,6 +73,8 @@ def valid_message_object():
         'eventId': EVENT_ID,
         'eventType': EVENT_TYPE,
         'timestamp': TIMESTAMP,
+        'originatingService': ORIGINATING_SERVICE,
+        'sessionId': SESSION_ID,
         'details': {
             'sessionEventType': SESSION_EVENT_TYPE
         }


### PR DESCRIPTION
The event recorder service's database schema has been changed to have a billing schema. The schema has a billing_events table and a fraud_events table. In MongoDB, it has a database called billingDb and it has 2 collections named 'billingEvents' and 'fraudEvents'. Both billing_events and fraud_events tables, and billingEvents and fraudEvents collections have same attributes. This change ensures that the event recorder service records billing events and fraud events properly.

Authors: @adityapahuja