### PR TITLE
qGlDDEZH/79: Inconsistent data in Billing and Fraud tables refactor

### DIFF
--- a/src/import_handler.py
+++ b/src/import_handler.py
@@ -27,11 +27,11 @@ def import_events(event, __):
                 message_envelope = json.loads(line)
                 event = event_from_json_object(message_envelope['document'])
 
-                write_audit_event_to_database(event, db_connection)
-                if event.event_type == 'session_event' and event.details.get('session_event_type') == 'idp_authn_succeeded':
-                    write_billing_event_to_database(event, db_connection)
-                if event.event_type == 'session_event' and event.details.get('session_event_type') == 'fraud_detected':
-                    write_fraud_event_to_database(event, db_connection)
+                if write_audit_event_to_database(event, db_connection):
+                    if event.event_type == 'session_event' and event.details.get('session_event_type') == 'idp_authn_succeeded':
+                        write_billing_event_to_database(event, db_connection)
+                    if event.event_type == 'session_event' and event.details.get('session_event_type') == 'fraud_detected':
+                        write_fraud_event_to_database(event, db_connection)
 
             except Exception as exception:
                 logging.getLogger('event-recorder').exception('Failed to store message{}'.format(exception))

--- a/test/import_handler_test.py
+++ b/test/import_handler_test.py
@@ -81,7 +81,7 @@ class ImportHandlerTest(TestCase):
         self.__assert_fraud_events_table_has_fraud_event_records([('session-id-3', 'fraud-event-id-1'), ('session-id-4', 'fraud-event-id-2')])
         self.__assert_import_file_has_been_removed_from_s3()
 
-    def test_does_not_write_dupicate_messages_to_db_with_password_from_env(self):
+    def test_does_not_write_duplicate_messages_to_db_with_password_from_env(self):
         self.__setup_s3()
         self.__setup_db_connection_string(True)
 
@@ -217,6 +217,7 @@ class ImportHandlerTest(TestCase):
                     WHERE
                         session_id = %s;
                 """, [session_id])
+                self.assertEqual(cursor.rowcount, 1)
                 matching_records = cursor.fetchone()
 
             self.assertIsNotNone(matching_records)
@@ -246,6 +247,7 @@ class ImportHandlerTest(TestCase):
                     WHERE
                         session_id = %s;
                 """, [fraud_event[0]])
+                self.assertEqual(cursor.rowcount, 1)
                 matching_records = cursor.fetchone()
 
             self.assertIsNotNone(matching_records)


### PR DESCRIPTION
Changed write_audit_event_to_database method so that it returns true if insert into audit event table succeeds.
Changed import handler to skip billing and fraud event tables if write_audit_event_to_database returns false.

Co-authored-by: George Lund <george.lund@digital.cabinet-office.gov.uk>