### PR TITLE
BAU: Fix Logging Errors from PR #34

### DIFF
--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -18,33 +18,47 @@ def store_queued_events(_, __):
     sqs_client = boto3.client('sqs')
     queue_url = os.environ['QUEUE_URL']
 
+    logger = logging.getLogger('event-recorder')
     if 'ENCRYPTION_KEY' in os.environ:
       encrypted_decryption_key = os.environ['ENCRYPTION_KEY']
+      logger.info('Got decryption key from environment variable')
     else:
       encrypted_decryption_key = fetch_decryption_key()
+      logger.info('Got decryption key from S3')
     decryption_key = decrypt(encrypted_decryption_key)
+    logger.info('Decrypted key successfully')
 
     database_password = None
     if 'ENCRYPTED_DATABASE_PASSWORD' in os.environ:
       # boto returns decrypted as b'bytes' so decode to convert to password string
       database_password = decrypt(os.environ['ENCRYPTED_DATABASE_PASSWORD']).decode()
     db_connection = create_db_connection(database_password)
+    logger.info('Created connection to DB')
 
+    event_count = 0
     while True:
         message = fetch_single_message(sqs_client, queue_url)
         if message is None:
+            logger.info('Queue is empty - finishing after {0} events'.format(event_count))
             break
+
+        event_count += 1
 
         # noinspection PyBroadException
         # catch all errors and log them - we never want a single failing message to kill the process.
         try:
             decrypted_message = decrypt_message(message['Body'], decryption_key)
             event = event_from_json(decrypted_message)
+            logger.info('Decrypted event with ID: {0}'.format(event.event_id))
             write_audit_event_to_database(event, db_connection)
+            logger.info('Stored audit event: {0}'.format(event.event_id))
             if event.event_type == 'session_event' and event.details.get('session_event_type') == 'idp_authn_succeeded':
                 write_billing_event_to_database(event, db_connection)
+                logger.info('Stored billing event: {0}'.format(event.event_id))
             if event.event_type == 'session_event' and event.details.get('session_event_type') == 'fraud_detected':
                 write_fraud_event_to_database(event, db_connection)
+                logger.info('Stored fraud event: {0}'.format(event.event_id))
             delete_message(sqs_client, queue_url, message)
+            logger.info('Deleted event from queue with ID: {0}'.format(event.event_id))
         except Exception as exception:
-            logging.getLogger('event-recorder').exception('Failed to store message')
+            logger.exception('Failed to store message')

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -144,16 +144,14 @@ class EventHandlerTest(TestCase):
             self.__assert_billing_events_table_has_no_billing_event_records
             self.__assert_fraud_events_table_has_no_fraud_event_records
             log_capture.check(
-                (
-                    'event-recorder',
-                    'WARNING',
-                    'Failed to store a billing event [Event ID sample-id-1] due to key error'
-                ),
-                (
-                    'event-recorder',
-                    'ERROR',
-                    'Failed to store message'
-                )
+                ('event-recorder', 'INFO', 'Got decryption key from S3'),
+                ('event-recorder', 'INFO', 'Decrypted key successfully'),
+                ('event-recorder', 'INFO', 'Created connection to DB'),
+                ('event-recorder', 'INFO', 'Decrypted event with ID: sample-id-1'),
+                ('event-recorder', 'INFO', 'Stored audit event: sample-id-1'),
+                ('event-recorder', 'WARNING', 'Failed to store a billing event [Event ID sample-id-1] due to key error'),
+                ('event-recorder', 'ERROR', 'Failed to store message'),
+                ('event-recorder', 'INFO', 'Queue is empty - finishing after 1 events')
             )
             self.assertEqual(self.__number_of_visible_messages(), '0')
             self.assertEqual(self.__number_of_hidden_messages(), '1')
@@ -173,16 +171,14 @@ class EventHandlerTest(TestCase):
             self.__assert_billing_events_table_has_no_billing_event_records
             self.__assert_fraud_events_table_has_no_fraud_event_records
             log_capture.check(
-                (
-                    'event-recorder',
-                    'WARNING',
-                    'Failed to store a fraud event [Event ID sample-id-1] due to key error'
-                ),
-                (
-                    'event-recorder',
-                    'ERROR',
-                    'Failed to store message'
-                )
+                ('event-recorder', 'INFO', 'Got decryption key from S3'),
+                ('event-recorder', 'INFO', 'Decrypted key successfully'),
+                ('event-recorder', 'INFO', 'Created connection to DB'),
+                ('event-recorder', 'INFO', 'Decrypted event with ID: sample-id-1'),
+                ('event-recorder', 'INFO', 'Stored audit event: sample-id-1'),
+                ('event-recorder', 'WARNING', 'Failed to store a fraud event [Event ID sample-id-1] due to key error'),
+                ('event-recorder', 'ERROR', 'Failed to store message'),
+                ('event-recorder', 'INFO', 'Queue is empty - finishing after 1 events')
             )
             self.assertEqual(self.__number_of_visible_messages(), '0')
             self.assertEqual(self.__number_of_hidden_messages(), '1')
@@ -203,11 +199,15 @@ class EventHandlerTest(TestCase):
             self.__assert_billing_events_table_has_billing_event_records(['session-id-2'])
             self.__assert_fraud_events_table_has_no_fraud_event_records
             log_capture.check(
-                (
-                    'event-recorder',
-                    'ERROR',
-                    'Failed to store message'
-                )
+                ('event-recorder', 'INFO', 'Got decryption key from S3'),
+                ('event-recorder', 'INFO', 'Decrypted key successfully'),
+                ('event-recorder', 'INFO', 'Created connection to DB'),
+                ('event-recorder', 'ERROR', 'Failed to store message'),
+                ('event-recorder', 'INFO', 'Decrypted event with ID: sample-id-2'),
+                ('event-recorder', 'INFO', 'Stored audit event: sample-id-2'),
+                ('event-recorder', 'INFO', 'Stored billing event: sample-id-2'),
+                ('event-recorder', 'INFO', 'Deleted event from queue with ID: sample-id-2'),
+                ('event-recorder', 'INFO', 'Queue is empty - finishing after 2 events')
             )
             self.assertEqual(self.__number_of_visible_messages(), '0')
             self.assertEqual(self.__number_of_hidden_messages(), '1')
@@ -228,11 +228,19 @@ class EventHandlerTest(TestCase):
             self.__assert_billing_events_table_has_billing_event_records(['session-id-1'])
             self.__assert_fraud_events_table_has_no_fraud_event_records
             log_capture.check(
-                (
-                    'event-recorder',
-                    'WARNING',
-                    'Failed to store an audit event. The Event ID sample-id-1 already exists in the database'
-                )
+                ('event-recorder', 'INFO', 'Got decryption key from S3'),
+                ('event-recorder', 'INFO', 'Decrypted key successfully'),
+                ('event-recorder', 'INFO', 'Created connection to DB'),
+                ('event-recorder', 'INFO', 'Decrypted event with ID: sample-id-1'),
+                ('event-recorder', 'INFO', 'Stored audit event: sample-id-1'),
+                ('event-recorder', 'INFO', 'Stored billing event: sample-id-1'),
+                ('event-recorder', 'INFO', 'Deleted event from queue with ID: sample-id-1'),
+                ('event-recorder', 'INFO', 'Decrypted event with ID: sample-id-1'),
+                ('event-recorder', 'WARNING', 'Failed to store an audit event. The Event ID sample-id-1 already exists in the database'),
+                ('event-recorder', 'INFO', 'Stored audit event: sample-id-1'),
+                ('event-recorder', 'INFO', 'Stored billing event: sample-id-1'),
+                ('event-recorder', 'INFO', 'Deleted event from queue with ID: sample-id-1'),
+                ('event-recorder', 'INFO', 'Queue is empty - finishing after 2 events')
             )
             self.assertEqual(self.__number_of_visible_messages(), '0')
             self.assertEqual(self.__number_of_hidden_messages(), '0')


### PR DESCRIPTION
PR #34 introduced additional logging, however, it contain an error (https://github.com/alphagov/verify-event-recorder-service/pull/34)
Corrected order of execution so that `event` is evaluated before being used in an log statement.