### PR TITLE
HJ63P95U: Modify event recorder to use new IAM authentication to DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,18 @@ in all events being exported from the database. See [Mongo Docs](https://docs.mo
 You should then download this file, over a secure connection, and upload to the S3 bucket configured as the trigger
 for the import_handler Lambda, this typically has the name `govukverify-event-importing-system-<environment>-import-files`
  
+### Environment Variables
+
+The following environment vars are should be defined in the lambda function:
+
+* `DB_CONNECTION_STRING` (_required_):- The connection string used to connect to the database. This should be of the format:
+`host=<hostname> dbname=<databasename> user=<username>`. The connection string could also contain `port=<portnumber>` if the database is listening on a non-standard port.
+* `QUEUE_URL` (_required_):- The URL to SQS queue to read events from. 
+* `ENCRYPTED_DATABASE_PASSWORD` (_optional_):- The password used to connect to the database, this should be KMS encrypted. If not provided the recorder
+will attempt to get an IAM token to connect to the database as the user specified in `DB_CONNECTION_STRING`.
+
+Also required is either:
+* `ENCRYPTION_KEY`:- the encryption key used to decrypt messages found in the queue.
+OR
+* `DECRYPTION_KEY_BUCKET_NAME`:- An S3 bucket name where a file containing the decryption key for events is stored.
+* `DECRYPTION_KEY_FILE_NAME`:- The file in the above containing the decryption key.

--- a/src/database.py
+++ b/src/database.py
@@ -8,10 +8,10 @@ from psycopg2.errorcodes import UNIQUE_VIOLATION
 from logging import getLogger
 
 
-def create_db_connection(database_password):
+def create_db_connection(dsn, database_password):
     if database_password:
-      return psycopg2.connect(os.environ['DB_CONNECTION_STRING'], password=database_password)
-    return psycopg2.connect(os.environ['DB_CONNECTION_STRING'])
+        return psycopg2.connect(dsn, password=database_password)
+    return psycopg2.connect(dsn)
 
 
 class RunInTransaction:

--- a/src/import_handler.py
+++ b/src/import_handler.py
@@ -1,21 +1,33 @@
 import logging
 import os
 import json
+import boto3
 
 from src.database import create_db_connection, write_audit_event_to_database, \
     write_billing_event_to_database, write_fraud_event_to_database
 from src.event_mapper import event_from_json_object
 from src.s3 import fetch_import_file, delete_import_file
 from src.kms import decrypt
-
-logging.basicConfig(level=logging.INFO)
+from psycopg2.extensions import parse_dsn
 
 
 def import_events(event, __):
+    logger = logging.getLogger('event-recorder')
+    logger.setLevel(logging.INFO)
+
+    dsn = os.environ['DB_CONNECTION_STRING']
+
     database_password = None
     if 'ENCRYPTED_DATABASE_PASSWORD' in os.environ:
+        # boto returns decrypted as b'bytes' so decode to convert to password string
         database_password = decrypt(os.environ['ENCRYPTED_DATABASE_PASSWORD']).decode()
-    db_connection = create_db_connection(database_password)
+    else:
+        dsn_components = parse_dsn(dsn)
+        database_password = boto3.client('rds').generate_db_auth_token(dsn_components['host'], 5432, dsn_components['user'])
+
+    db_connection = create_db_connection(dsn, database_password)
+    logger.info('Created connection to DB')
+
     for record in event['Records']:
         bucket = record['s3']['bucket']['name']
         filename = record['s3']['object']['key']
@@ -34,6 +46,6 @@ def import_events(event, __):
                         write_fraud_event_to_database(event, db_connection)
 
             except Exception as exception:
-                logging.getLogger('event-recorder').exception('Failed to store message{}'.format(exception))
+                logger.exception('Failed to store message{}'.format(exception))
 
         delete_import_file(bucket, filename)

--- a/test/import_handler_test.py
+++ b/test/import_handler_test.py
@@ -104,6 +104,11 @@ class ImportHandlerTest(TestCase):
             log_capture.check(
                 (
                     'event-recorder',
+                    'INFO',
+                    'Created connection to DB'
+                ),
+                (
+                    'event-recorder',
                     'WARNING',
                     'Failed to store an audit event. The Event ID sample-id-1 already exists in the database'
                 ),


### PR DESCRIPTION
IAM database authentication is now enabled on RDS and new user, `iam_writer`, has been created.
This change alters the recorder, and import service, to get an IAM authentication token if the
database password is not provided in the environment (in the `ENCRYPTED_DATABASE_PASSWORD` environment variable`).