### PR TITLE
 8WXtKLdP: Clean up old DB Writer users and passwords

### DIFF
--- a/database-schema/permissions/revoke_writer_permissions.sql
+++ b/database-schema/permissions/revoke_writer_permissions.sql
@@ -1,0 +1,7 @@
+REVOKE USAGE ON SCHEMA audit FROM writer;
+REVOKE USAGE ON SCHEMA billing FROM writer;
+REVOKE SELECT, INSERT, DELETE ON audit.audit_events FROM writer;
+REVOKE SELECT, INSERT, DELETE ON billing.billing_events FROM writer;
+REVOKE SELECT, INSERT, DELETE ON billing.fraud_events FROM writer;
+-- Production and staging only
+REVOKE SELECT, INSERT, DELETE ON billing.billing_idps FROM writer;


### PR DESCRIPTION
Record of `REVOKE` statements used to remove rights for old `writer` user.