### PR TITLE
Add Temporary permission for iam_reader user

### DIFF
--- a/database-schema/permissions/create_iam_reader_permissions.sql
+++ b/database-schema/permissions/create_iam_reader_permissions.sql
@@ -3,5 +3,6 @@ GRANT USAGE ON SCHEMA billing TO iam_reader;
 GRANT SELECT ON audit.audit_events TO iam_reader;
 GRANT SELECT ON billing.billing_events TO iam_reader;
 GRANT SELECT ON billing.fraud_events TO iam_reader;
+GRANT TEMPORARY on DATABASE events TO iam_reader;
 -- Production and staging only
 GRANT SELECT ON billing.billing_idps TO iam_reader;


### PR DESCRIPTION
The iam_reader user also needs to have `TEMPORARY` permission in order to create the temporary tables when running the rp_billing report.

This change is made manually on the db at the moment and reflects things that have already been applied.