### PR TITLE
Initial Splunk fraud event logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,7 @@ RUN python3 -m pip install -r requirements/dev.txt
 COPY src src
 COPY test test
 
+ENV SPLUNK_HEC_TOKEN_TEST blank
+
 ENTRYPOINT ["python3"]
-CMD ["-m", "unittest", "discover", "test/", "*_test.py"]
+CMD ["-m", "unittest", "discover", "test/", "*_test.py", "-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN python3 -m pip install -r requirements/dev.txt
 COPY src src
 COPY test test
 
-ENV SPLUNK_HEC_TOKEN_TEST blank
+#ENV SPLUNK_HEC_TOKEN_TEST XXXXXXXXXXXXX
 
 ENTRYPOINT ["python3"]
-CMD ["-m", "unittest", "discover", "test/", "*_test.py", "-v"]
+CMD ["-m", "unittest", "discover", "test/", "*_test.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,5 @@ services:
     build: .
     depends_on:
       - event-store
+    environment:
+      - SPLUNK_HEC_TOKEN_TEST

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,3 @@
 psycopg2-binary==2.7.4
 cryptography==2.3.1
+requests==2.22.0

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -11,7 +11,7 @@ from src.event_mapper import event_from_json
 from src.kms import decrypt
 from src.s3 import fetch_decryption_key
 from src.sqs import fetch_single_message, delete_message
-from src.pysplunkhec import push_event_to_splunk
+from src.splunkeventsender import push_event_to_splunk
 
 
 # noinspection PyUnusedLocal

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -70,7 +70,6 @@ def store_queued_events(_, __):
                 logger.info('Stored fraud event: {0}'.format(event.event_id))
 
                 # really don't want the event system to fail because of Splunk logging
-                splunk_res = False
                 try:
                     splunk_res = push_event_to_splunk(decrypted_message)
                 except Exception as e:
@@ -79,7 +78,7 @@ def store_queued_events(_, __):
                 if splunk_res and splunk_res[0] == 200:
                     # log successfully pushed events
                     logger.info('Pushed fraud event to Splunk: {0}'.format(event.event_id))
-                else:
+                elif 'production' in os.environ['QUEUE_URL']:
                     # log unsuccessful push events as errors but don't raise an exception
                     # this way, if Splunk was down, the event system still works as expected
                     logger.error('Failed to push fraud event to Splunk: {0}'.format(event.event_id))

--- a/src/pysplunkhec.py
+++ b/src/pysplunkhec.py
@@ -1,0 +1,89 @@
+# the following allows JSON to be posted to Splunk HEC (HTTP Event Collector)
+
+import os
+import requests
+import json
+from src.kms import decrypt
+
+class PySplunkHEC:
+    def __init__(
+        self,
+        hec_token,
+        hec_host,
+        index="main",
+        host="null",
+        source="null",
+        sourcetype="json",
+        hec_port='443'
+        ):
+        self.index = index
+        self.host = host
+        self.source = source
+        self.sourcetype = sourcetype
+        self.hec_token = hec_token
+        self.uri = "https://" + hec_host + ":" + hec_port + "/services/collector"
+
+    def base_json_event(self):
+        return {
+            "host": self.host,
+            "source": self.source,
+            "sourcetype": self.sourcetype,
+            "index": self.index,
+            "event": {},
+            }
+
+    def send(self, payload):
+        headers = {
+            'Authorization': 'Splunk ' + self.hec_token,
+            'Content-Type': 'application/json'
+            }
+
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+
+        json_event = self.base_json_event()
+
+        if "timestamp" in payload:
+            json_event["time"] = payload["timestamp"]
+
+        json_event["event"] = json.dumps(payload)
+
+        event = str(json.dumps(json_event))
+
+        res = False
+        try:
+            r = requests.post(self.uri, data=event, headers=headers, verify=True)
+            res = r.status_code, r.text,
+        except Exception as e:
+            print("PySplunkHEC:send:", e)
+            res = False
+        return res
+
+def push_event_to_splunk(event):
+    have_vars = True
+    for var in [
+        "SPLUNK_HEC_TOKEN",
+        "SPLUNK_HEC_HOST",
+        "SPLUNK_HEC_PORT",
+        "SPLUNK_HEC_INDEX",
+        ]:
+        if var not in os.environ:
+            raise Exception("'{0}' not set".format(var))
+            have_vars = False
+
+    if have_vars:
+        s_tokn = decrypt(os.environ['SPLUNK_HEC_TOKEN']).decode()
+        s_host = os.environ['SPLUNK_HEC_HOST']
+        s_port = os.environ['SPLUNK_HEC_PORT']
+        s_indx = os.environ['SPLUNK_HEC_INDEX']
+
+        if s_tokn and s_host and s_port and s_indx:
+            hec = PySplunkHEC(
+                hec_token=s_tokn,
+                hec_host=s_host,
+                hec_port=s_port,
+                index=s_indx,
+            )
+            return hec.send(event)
+
+    return False

--- a/src/splunkeventsender.py
+++ b/src/splunkeventsender.py
@@ -34,7 +34,7 @@ class SplunkEventSender:
         }
 
     def send(self, payload):
-        logger = logging.getLogger('py-splunk-hec')
+        logger = logging.getLogger('splunk-event-send')
         logger.setLevel(logging.INFO)
 
         headers = {
@@ -64,21 +64,24 @@ class SplunkEventSender:
 
 
 def push_event_to_splunk(event):
+    logger = logging.getLogger('push-event-to-splunk')
+    logger.setLevel(logging.INFO)
+
     if 'production' in os.environ['QUEUE_URL'] 
 
         for var in [
             "SPLUNK_HEC_TOKEN",
-	    "SPLUNK_HEC_HOST",
-	    "SPLUNK_HEC_PORT",
-	    "SPLUNK_HEC_INDEX",
-	]:
-	    if var not in os.environ:
+            "SPLUNK_HEC_HOST",
+            "SPLUNK_HEC_PORT",
+            "SPLUNK_HEC_INDEX",
+        ]:
+            if var not in os.environ:
                 logger.info("'{0}' not set".format(var))
         try:
             s_tokn = decrypt(os.environ['SPLUNK_HEC_TOKEN']).decode()
         except Exception as e:
-		logger.error("splunk-hec-token:failed-to-decrypt:", e)
-                return  False
+            logger.error("splunk-hec-token:failed-to-decrypt:", e)
+            return  False
 
         s_host = os.environ['SPLUNK_HEC_HOST']
         s_port = os.environ['SPLUNK_HEC_PORT']

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -15,6 +15,7 @@ from src import event_handler
 from src.database import RunInTransaction
 from test.test_encrypter import encrypt_string
 
+
 EVENT_TYPE = 'session_event'
 TIMESTAMP = 1518264452000 # '2018-02-10 12:07:32'
 ORIGINATING_SERVICE = 'test service'
@@ -30,7 +31,7 @@ PROVIDED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
 REQUIRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
 FRAUD_SESSION_EVENT_TYPE = 'fraud_detected'
 GPG45_STATUS = 'AA01'
-SPLUNK_HEC_TOKEN = os.getenv('SPLUNK_HEC_TOKEN_TEST', 'blank')
+SPLUNK_HEC_TOKEN = os.getenv('SPLUNK_HEC_TOKEN_TEST', None)
 SPLUNK_HEC_HOST = 'http-inputs-gds.splunkcloud.com'
 SPLUNK_HEC_PORT = '443'
 SPLUNK_HEC_INDEX = 'test_data'
@@ -444,7 +445,7 @@ class EventHandlerTest(TestCase):
             self.assertEqual(matching_records[6], GPG45_STATUS)
 
     def __setup_splunk_hec(self):
-        if SPLUNK_HEC_TOKEN != "blank":
+        if SPLUNK_HEC_TOKEN is not None:
             os.environ['SPLUNK_HEC_TOKEN'] = self.__encrypt(SPLUNK_HEC_TOKEN)
         else:
             os.environ['SPLUNK_HEC_TOKEN'] = False


### PR DESCRIPTION
- New `pysplunkhec.py` file to push JSON to Splunk HEC (HTTP Event Collector)
- Takes four env variables:
  - SPLUNK_HEC_TOKEN (KMS encrypted) : private API token
  - SPLUNK_HEC_HOST
  - SPLUNK HEC_PORT
  - SPLUNK_HEC_INDEX : where the events will log in Splunk
- Added logic to `event_handler.py` with try around, so if Splunk logging is broken/the API is down then doesn't, in theory, kill the event system
- Tweaked `Dockerfile` / `docker-compose.yml` to be able to pass `SPLUNK_HEC_TOKEN_TEST` host env variable