### PR TITLE
Check for AWS credentials being committed

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -1,6 +1,24 @@
 #!/bin/bash
 set -eu
 
+if [[ ! $(git secrets 2>/dev/null) ]]; then
+  echo "⚠️ This repository should be checked against leaked AWS credentials ⚠️"
+  echo "We highly recommend you run the following:"
+  echo "   brew install git-secrets"
+  echo "then to set up the git-secrets to run on each commit:"
+  echo "   git secrets --install"
+  echo "   git secrets --register-aws"
+  echo " === !!! !!! !!! === "
+  exit 1
+else
+  for hook in .git/hooks/commit-msg .git/hooks/pre-commit .git/hooks/prepare-commit-msg; do
+    if ! grep -q "git secrets" $hook; then
+      git secrets --install -f
+    fi
+  done
+  git secrets --register-aws
+fi
+
 if ! command -v pre-commit 2>/dev/null; then
   echo "This repository has configuration for running pre-commit automatically"
   echo "via the pre-commit.com tooling. We highly recommend you run the following:"


### PR DESCRIPTION
In response to an incident, we're adding a check to our pre-commit scripts
to ensure no AWS credentials are being committed. It's using the AWS-provided
git secrets script - https://github.com/awslabs/git-secrets