### PR TITLE
Wu7e9auF: Update Billing Recorder to populate event_id column on billing_events

### DIFF
--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-docker-compose build
+docker-compose build --no-cache
 docker-compose run --rm tests
 exit_code=$?
 docker-compose down

--- a/src/database.py
+++ b/src/database.py
@@ -62,9 +62,9 @@ def write_billing_event_to_database(event, db_connection):
         with RunInTransaction(db_connection) as cursor:
             cursor.execute("""
                 INSERT INTO billing.billing_events
-                (time_stamp, session_id, hashed_persistent_id, request_id, idp_entity_id, minimum_level_of_assurance, required_level_of_assurance, provided_level_of_assurance)
+                (time_stamp, session_id, hashed_persistent_id, request_id, idp_entity_id, minimum_level_of_assurance, required_level_of_assurance, provided_level_of_assurance, event_id)
                 VALUES
-                (%s, %s, %s, %s, %s, %s, %s, %s);
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s);
             """, [
                 datetime.fromtimestamp(int(event.timestamp) / 1e3),
                 event.session_id,
@@ -73,7 +73,8 @@ def write_billing_event_to_database(event, db_connection):
                 event.details['idp_entity_id'],
                 event.details['minimum_level_of_assurance'],
                 event.details['required_level_of_assurance'],
-                event.details['provided_level_of_assurance']
+                event.details['provided_level_of_assurance'],
+                event.event_id
             ])
     except KeyError as keyError:
         getLogger('event-recorder').warning('Failed to store a billing event [Event ID {0}] due to key error'.format(event.event_id))


### PR DESCRIPTION
## What

The `billing_events` table current has no primary key defined. It has been determined that we should ideally use the event_id for this. Unfortunately, event_id is not currently stored in this table.

This card is to update the billing recorder service to populate the `event_id` column when creating new `billing_events`.

## Why

Storing the `event_id` will enable efficient joins to both the `audit_events` table and the new `billing_status` table.

## How

Update tests to check for `event_id` value
Add `event_id` column to `INSERT` statement in `database.write_billing_event_to_database`
Also updated `run-test.sh` to tell Docker not use layer cache as it was using cached version of Postgres image rather than pulling latest migration scripts.