### PR TITLE
Switch to using Bourne instead of Bash shell in `package.sh`

### DIFF
--- a/build/package.sh
+++ b/build/package.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -eu
 cd "$(dirname "$0")/../"
 


### PR DESCRIPTION
This is needed because the Docker image `dcind` to be used by a Concourse build task does not have Bash.

A similar change was made to `verify-event-system-alarm-notifier` repo in this [PR](https://github.com/alphagov/verify-event-system-alarm-notifier/pull/2).