### PR TITLE
lf6wlZNL: Fix Tests and Database Migration Handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION=../verify-event-system-database-scripts

--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
+# Default value for use with docker-compose.yml
 VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION=../verify-event-system-database-scripts

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ The database scripts live in [verify-event-system-database-scripts](https://gith
 The `./build/run-tests.sh` script expects to find the above repo, checked out, in the `../verify-event-system-database-scripts`
 directory. If it does not find it there, it will automatically clone it to that location. If you have, or would like, the repo stored elsewhere
 you can override this behaviour by setting the `VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION` to the required path before running
-the test script.
+the test script. If running docker-compose manually, a default value for the `VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION` environment 
+variable is set in `.env`.
 
 The `./build/run-tests.sh` script will then build the database migration image and use that image to populate a local
 PostgreSQL container with the correct schema.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ Running pre-commit will start docker-compose with Postgres and our code then run
 
 The database scripts live in [verify-event-system-database-scripts](https://github.com/alphagov/verify-event-system-database-scripts).
 
-The tests currently rely on scripts in the migrations directory of the above repo.
+The `./build/run-tests.sh` script expects to find the above repo, checked out, in the `../verify-event-system-database-scripts`
+directory. If it does not find it there, it will automatically clone it to that location.
+
+The `./build/run-tests.sh` script will then build the database migration image and use that image to populate a local
+PostgreSQL container with the correct schema.
+
+If you have related database migration scripts that need to be in place in order for tests to pass, ensure you 
+have the correct branch checked out.
 
 ## Using pre-commit hooks
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Running pre-commit will start docker-compose with Postgres and our code then run
 The database scripts live in [verify-event-system-database-scripts](https://github.com/alphagov/verify-event-system-database-scripts).
 
 The `./build/run-tests.sh` script expects to find the above repo, checked out, in the `../verify-event-system-database-scripts`
-directory. If it does not find it there, it will automatically clone it to that location.
+directory. If it does not find it there, it will automatically clone it to that location. If you have, or would like, the repo stored elsewhere
+you can override this behaviour by setting the `VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION` to the required path before running
+the test script.
 
 The `./build/run-tests.sh` script will then build the database migration image and use that image to populate a local
 PostgreSQL container with the correct schema.

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -17,9 +17,7 @@ echo Database Scripts are located at: ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOC
 
 if [[ ! -d "${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}" ]]; then
     echo "Cloning database migration scripts repo..."
-    pushd ${SCRIPT_DIR}/../..
-    git clone git@github.com:alphagov/verify-event-system-database-scripts.git
-    popd
+    git clone git@github.com:alphagov/verify-event-system-database-scripts.git ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}
 fi
 
 pushd ${SCRIPT_DIR}/.. > /dev/null

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -1,5 +1,7 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 set -e
+
+SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
 function stop_containers() {
   docker-compose down
@@ -7,19 +9,32 @@ function stop_containers() {
 
 trap stop_containers EXIT
 
-if [[ ! -d ../verify-event-system-database-scripts ]]; then
+if [[ -z "${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}" ]]; then
+    export VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION=${SCRIPT_DIR}/../../verify-event-system-database-scripts
+fi
+
+echo Database Scripts are located at: ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}
+
+if [[ ! -d "${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}" ]]; then
     echo "Cloning database migration scripts repo..."
-    pushd ..
+    pushd ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}/..
     git clone git@github.com:alphagov/verify-event-system-database-scripts.git
     popd
 fi
 
-echo "Building test imgages..."
+pushd ${SCRIPT_DIR}/.. > /dev/null
+echo "Building test images..."
 docker-compose build
 
 echo "Starting up database..."
 docker-compose up -d event-store
+
+echo "Giving time for database to initialise..."
+sleep 3
+
+echo "Run database migrations..."
 docker-compose run flyway migrate
 
 echo "Run Tests..."
 docker-compose run --rm tests
+popd > /dev/null

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -17,7 +17,7 @@ echo Database Scripts are located at: ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOC
 
 if [[ ! -d "${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}" ]]; then
     echo "Cloning database migration scripts repo..."
-    pushd ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}/..
+    pushd ${SCRIPT_DIR}/../..
     git clone git@github.com:alphagov/verify-event-system-database-scripts.git
     popd
 fi

--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -1,7 +1,25 @@
 #!/usr/bin/env bash
+set -e
 
-docker-compose build --no-cache
+function stop_containers() {
+  docker-compose down
+}
+
+trap stop_containers EXIT
+
+if [[ ! -d ../verify-event-system-database-scripts ]]; then
+    echo "Cloning database migration scripts repo..."
+    pushd ..
+    git clone git@github.com:alphagov/verify-event-system-database-scripts.git
+    popd
+fi
+
+echo "Building test imgages..."
+docker-compose build
+
+echo "Starting up database..."
+docker-compose up -d event-store
+docker-compose run flyway migrate
+
+echo "Run Tests..."
 docker-compose run --rm tests
-exit_code=$?
-docker-compose down
-exit $exit_code

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,20 @@ version: '3.4'
 
 services:
   event-store:
-    build:
-      context: .
-      dockerfile: postgres.Dockerfile
+    image: postgres:10.6
     environment:
       POSTGRES_DB: events
+    volumes:
+      - ../verify-event-system-database-scripts/test-initialise-scripts:/docker-entrypoint-initdb.d
+
+  flyway:
+    build:
+      context: ../verify-event-system-database-scripts
+      dockerfile: Dockerfile
+    env_file:
+      - test.env
+    depends_on:
+      - event-store
 
   tests:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,11 +6,11 @@ services:
     environment:
       POSTGRES_DB: events
     volumes:
-      - ../verify-event-system-database-scripts/test-initialise-scripts:/docker-entrypoint-initdb.d
+      - ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}/test-initialise-scripts:/docker-entrypoint-initdb.d
 
   flyway:
     build:
-      context: ../verify-event-system-database-scripts
+      context: ${VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION}
       dockerfile: Dockerfile
     env_file:
       - test.env

--- a/postgres.Dockerfile
+++ b/postgres.Dockerfile
@@ -1,6 +1,0 @@
-FROM postgres
-
-RUN apt-get update && apt-get install -y git-core
-RUN git clone --depth=1 https://github.com/alphagov/verify-event-system-database-scripts.git db-repo \
-  && cp db-repo/migrations/*.sql /docker-entrypoint-initdb.d/ \
-  && cp db-repo/test-initialise-scripts/*.sql /docker-entrypoint-initdb.d/

--- a/test.env
+++ b/test.env
@@ -1,0 +1,5 @@
+PGHOST=event-store
+PGUSER=dbmigrator
+PGPASSWORD=password
+PGDATABASE=events
+USE_IAM_AUTH=0

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -240,8 +240,7 @@ class EventHandlerTest(TestCase):
                 ('event-recorder', 'INFO', 'Stored audit event: sample-id-1'),
                 ('event-recorder',
                  'WARNING',
-                 'Failed to store a billing event. The Event ID sample-id-1 already exists in '
-                 'the database'),
+                 'Failed to store a billing event. The Event ID sample-id-1 already exists in the database'),
                 ('event-recorder', 'INFO', 'Stored billing event: sample-id-1'),
                 ('event-recorder', 'INFO', 'Deleted event from queue with ID: sample-id-1'),
                 ('event-recorder', 'INFO', 'Queue is empty - finishing after 2 events')

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -238,6 +238,10 @@ class EventHandlerTest(TestCase):
                 ('event-recorder', 'INFO', 'Decrypted event with ID: sample-id-1'),
                 ('event-recorder', 'WARNING', 'Failed to store an audit event. The Event ID sample-id-1 already exists in the database'),
                 ('event-recorder', 'INFO', 'Stored audit event: sample-id-1'),
+                ('event-recorder',
+                 'WARNING',
+                 'Failed to store a billing event. The Event ID sample-id-1 already exists in '
+                 'the database'),
                 ('event-recorder', 'INFO', 'Stored billing event: sample-id-1'),
                 ('event-recorder', 'INFO', 'Deleted event from queue with ID: sample-id-1'),
                 ('event-recorder', 'INFO', 'Queue is empty - finishing after 2 events')


### PR DESCRIPTION
## What

The tests are broken for two reasons:
1) The log output is has changed since the introduction of the `event_id` column to the `billing_events` table.
2) The use of a "repeatable" migration in the database scripts repo has means the PostgreSQL initialise scripts run in the wrong order and the event-store service fails to start.

We need to ensure a sensible log output and set the expectations appropriately in the tests.

We should use Flyway to apply the migration scripts to local database instance to ensure consistent behaviour.

## Why

We can't run tests successfully == potential bugs

## How

Fix logging and log expectation since introduction of unique `event_id` column to `billing_events` table.
Improve error handling in `build/run-tests.sh`.
Update `docker-compose.yml` to include Flyway task to run migrations.
Remove requirement for custom PostgreSQL Docker image.
Add automatic cloning of required `verify-event-system-database-scripts` repo if not already present in parent directory.
Update `README.md` with new information about database schemas.
Use `sh` instead of `bash` (required for DCinD on Concourse).
Update `run-tests.sh` to correctly evaluate relative directories
Allow use of environment variable to specify database script repo
location. This allows use of environment variable in `docker-compose.yml`.
Add `.env` to specify default values for environment variable for use
with standalone docker-compose.
Add a short wait to allow Postgres time to initialise before running
migrations.
Fix string formatting as per PR review.
Add comment to `.env` to explain purpose.
Update README to explain `.env`.
Amend `run-tests.sh` to change directory relative to $SCRIPT_DIR rather than $VERIFY_EVENT_SYSTEM_DATABASE_SCRIPTS_LOCATION when cloning repo.

## Todo

We need to update pipeline to actually run these tests as, currently, it just builds and deploys the lambda :-(