### PR TITLE
Ndcbw4d3 add service name to billing report

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -62,9 +62,20 @@ def write_billing_event_to_database(event, db_connection):
         with RunInTransaction(db_connection) as cursor:
             cursor.execute("""
                 INSERT INTO billing.billing_events
-                (time_stamp, session_id, hashed_persistent_id, request_id, idp_entity_id, minimum_level_of_assurance, required_level_of_assurance, provided_level_of_assurance, event_id)
+                (
+                    time_stamp,
+                    session_id,
+                    hashed_persistent_id,
+                    request_id,
+                    idp_entity_id,
+                    minimum_level_of_assurance,
+                    required_level_of_assurance,
+                    provided_level_of_assurance,
+                    event_id,
+                    transaction_entity_id
+                )
                 VALUES
-                (%s, %s, %s, %s, %s, %s, %s, %s, %s);
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             """, [
                 datetime.fromtimestamp(int(event.timestamp) / 1e3),
                 event.session_id,
@@ -74,7 +85,8 @@ def write_billing_event_to_database(event, db_connection):
                 event.details['minimum_level_of_assurance'],
                 event.details['required_level_of_assurance'],
                 event.details['provided_level_of_assurance'],
-                event.event_id
+                event.event_id,
+                event.details['transaction_entity_id']
             ])
     except KeyError as keyError:
         getLogger('event-recorder').warning('Failed to store a billing event [Event ID {0}] due to key error'.format(event.event_id))

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -382,7 +382,8 @@ class EventHandlerTest(TestCase):
                         minimum_level_of_assurance,
                         required_level_of_assurance,
                         provided_level_of_assurance,
-                        event_id
+                        event_id,
+                        transaction_entity_id
                     FROM
                         billing.billing_events
                     WHERE
@@ -400,6 +401,7 @@ class EventHandlerTest(TestCase):
             self.assertEqual(matching_records[6], PROVIDED_LEVEL_OF_ASSURANCE)
             self.assertEqual(matching_records[7], REQUIRED_LEVEL_OF_ASSURANCE)
             self.assertEqual(matching_records[8], event_id)
+            self.assertEqual(matching_records[9], TRANSACTION_ENTITY_ID)
 
     def __assert_fraud_events_table_has_no_fraud_event_records(self):
         with RunInTransaction(self.db_connection) as cursor:


### PR DESCRIPTION
## What

We often need to know which service to associate a billable event with. We do this by running the 'verifications by RP' report, which uses some data from the billing report but adds in a column containing the service name for each report.

We could just include that column in the billing report.

## Why

We could stop running the verifications by RP report. 

Secondary reports that use that report could be simplified.

## How

Change `write_billing_event_to_database()` to also write `transaction_entity_id` from original event details.