### PR TITLE
Cyber-Jira-CE366: Splunk Logging Lambda

### DIFF
--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -11,6 +11,7 @@ from src.event_mapper import event_from_json
 from src.kms import decrypt
 from src.s3 import fetch_decryption_key
 from src.sqs import fetch_single_message, delete_message
+from src.fraud_log_invoker import send_to_fraud_logger
 
 
 # noinspection PyUnusedLocal
@@ -67,6 +68,8 @@ def store_queued_events(_, __):
             if event.event_type == 'session_event' and event.details.get('session_event_type') == 'fraud_detected':
                 write_fraud_event_to_database(event, db_connection)
                 logger.info('Stored fraud event: {0}'.format(event.event_id))
+                send_to_fraud_logger(event)
+
             delete_message(sqs_client, queue_url, message)
             logger.info('Deleted event from queue with ID: {0}'.format(event.event_id))
         except Exception as exception:

--- a/src/fraud_handler.py
+++ b/src/fraud_handler.py
@@ -1,0 +1,109 @@
+import os
+import logging
+import json
+import boto3
+from datetime import datetime
+from botocore.errorfactory import ClientError
+import random
+import string
+
+
+class VerifyFraudToS3:
+
+
+    def __init__(
+        self,
+        key,
+        bucket,
+        role,
+        s_index,
+        s_sourcetype="json",
+        s_source="null",
+        s_host="null"
+        ):
+
+        self.key = key
+        self.bucket = bucket
+        self.role = role
+        self.s_index = s_index
+        self.s_sourcetype = s_sourcetype
+        self.s_source = s_source
+        self.s_host = s_host
+
+
+    def base_json_event(self):
+        return {
+            "host": self.s_host,
+            "source": self.s_source,
+            "sourcetype": self.s_sourcetype,
+            "index": self.s_index,
+            "event": {},
+            }
+
+
+    def aws_session(self, role, session_name='session_verify_fraud_logging'):
+        logger = logging.getLogger('assume-role')
+        logger.setLevel(logging.INFO)
+
+        try:
+            client = boto3.client('sts')
+            response = client.assume_role(RoleArn=self.role, RoleSessionName=session_name)
+            session = boto3.Session(
+                aws_access_key_id=response['Credentials']['AccessKeyId'],
+                aws_secret_access_key=response['Credentials']['SecretAccessKey'],
+                aws_session_token=response['Credentials']['SessionToken'])
+            return session
+        except ClientError as e:
+            logger.error('Unable to assume a session. {0}'.format(e))
+            raise e
+
+    def push_to_s3(self, payload):
+        logger = logging.getLogger('push-to-s3')
+        logger.setLevel(logging.INFO)
+
+        session_assumed = self.aws_session(self.role)
+        logger.info(session_assumed.client('sts').get_caller_identity()['Account'])
+
+        s3 = session_assumed.resource('s3')
+
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        json_event = self.base_json_event()
+
+        try:
+            if "timestamp" in payload:
+                json_event["time"] = payload["timestamp"]
+        except TypeError as te:
+            logger.info('Timestamp not set. {0}'.format(te))
+            pass
+
+        json_event["event"] = json.dumps(payload)
+        event = str(json.dumps(json_event))
+
+        try:
+            s3.Object(self.bucket, self.key).put(
+                    Body=(bytes(json.dumps(event, indent=2).encode('UTF-8')))
+                )
+        except ClientError as e:
+            logger.error('Unable to write to S3 bucket. {0}'.format(e))
+            raise e
+
+
+def fraud_logging_handler(event, context):
+
+    bucket = os.environ['SPLUNK_VERIFY_FRAUD_S3_NAME']
+    role = os.environ['SPLUNK_S3_BUCKET_ROLE']
+    s_index = os.environ['SPLUNK_INDEX']
+    today = str(datetime.now())
+    letters = string.ascii_lowercase
+    random_string = ''.join(random.choice(letters) for i in range(8))
+    key = 'verify-fraud-events-{}-{}.log'.format(random_string, today)
+
+
+    verify_to_s3 = VerifyFraudToS3(
+        key,
+        bucket,
+        role,
+        s_index,
+    )
+    return verify_to_s3.push_to_s3(event)

--- a/src/fraud_log_invoker.py
+++ b/src/fraud_log_invoker.py
@@ -1,0 +1,21 @@
+import json
+import boto3
+from datetime import datetime
+
+def convert_to_json(event):
+    return {
+        'time_stamp': str(datetime.fromtimestamp(int(event.timestamp) / 1e3)),
+        'session_id': event.session_id,
+        'hashed_persistent_id': event.details['pid'],
+        'request_id': event.details['request_id'],
+        'entity_id': event.details['idp_entity_id'],
+        'fraud_event_id': event.details['idp_fraud_event_id'],
+        'fraud_indicator': event.details['gpg45_status']
+    }
+
+def send_to_fraud_logger(event):
+    lambda_client = boto3.client('lambda')
+    lambda_client.invoke(FunctionName='fraud_handler',
+    InvocationType='Event',
+    Payload=json.dumps(convert_to_json(event)),
+    )

--- a/src/import_handler.py
+++ b/src/import_handler.py
@@ -9,6 +9,7 @@ from src.event_mapper import event_from_json_object
 from src.s3 import fetch_import_file, delete_import_file
 from src.kms import decrypt
 from psycopg2.extensions import parse_dsn
+from src.fraud_log_invoker import send_to_fraud_logger
 
 
 def import_events(event, __):
@@ -44,6 +45,7 @@ def import_events(event, __):
                         write_billing_event_to_database(event, db_connection)
                     if event.event_type == 'session_event' and event.details.get('session_event_type') == 'fraud_detected':
                         write_fraud_event_to_database(event, db_connection)
+                        send_to_fraud_logger(event)
 
             except Exception as exception:
                 logger.exception('Failed to store message{}'.format(exception))

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -13,6 +13,7 @@ from retrying import retry
 from src import event_handler
 from src.database import RunInTransaction
 from test.test_encrypter import encrypt_string
+from test.fraud_invoke_test import setup_lambda
 
 EVENT_TYPE = 'session_event'
 TIMESTAMP = 1518264452000 # '2018-02-10 12:07:32'
@@ -62,6 +63,7 @@ class EventHandlerTest(TestCase):
 
     def test_reads_messages_from_queue_with_key_from_s3(self):
         self.__setup_s3()
+        setup_lambda()
         self.__encrypt_and_send_to_sqs(
             [
                 create_event_string('sample-id-1', 'session-id-1'),
@@ -82,6 +84,7 @@ class EventHandlerTest(TestCase):
 
     def test_reads_fraud_events_from_queue(self):
         self.__setup_s3()
+        setup_lambda()
         self.__encrypt_and_send_to_sqs(
             [
                 create_fraud_event_string('sample-id-1', 'session-id-1', 'fraud-event-id-1'),
@@ -116,6 +119,7 @@ class EventHandlerTest(TestCase):
 
     def test_writes_messages_to_db_with_password_from_env(self):
         self.__setup_s3()
+        setup_lambda()
         self.__setup_db_connection_string(True)
         self.__encrypt_and_send_to_sqs(
             [
@@ -131,6 +135,7 @@ class EventHandlerTest(TestCase):
 
     def test_writes_incomplete_billing_event_to_audit_events_table_but_not_to_billing_events_table(self):
         self.__setup_s3()
+        setup_lambda()
         with LogCapture('event-recorder', propagate=False) as log_capture:
             message_ids = self.__encrypt_and_send_to_sqs(
                 [
@@ -158,6 +163,7 @@ class EventHandlerTest(TestCase):
 
     def test_writes_incomplete_fraud_event_to_audit_events_table_but_not_to_fraud_events_table(self):
         self.__setup_s3()
+        setup_lambda()
         with LogCapture('event-recorder', propagate=False) as log_capture:
             message_ids = self.__encrypt_and_send_to_sqs(
                 [
@@ -185,6 +191,7 @@ class EventHandlerTest(TestCase):
 
     def test_does_not_delete_invalid_messages(self):
         self.__setup_s3()
+        setup_lambda()
         with LogCapture('event-recorder', propagate=False) as log_capture:
             message_ids = self.__encrypt_and_send_to_sqs(
                 [
@@ -214,6 +221,7 @@ class EventHandlerTest(TestCase):
 
     def test_records_error_but_does_delete_messages_for_duplicate_events(self):
         self.__setup_s3()
+        setup_lambda()
         with LogCapture('event-recorder', propagate=False) as log_capture:
             self.__encrypt_and_send_to_sqs(
                 [
@@ -491,7 +499,7 @@ class EventHandlerTest(TestCase):
 
 def setup_stub_aws_config():
     os.environ = {
-        'AWS_DEFAULT_REGION': 'eu-west-2',
+        'AWS_DEFAULT_REGION': 'us-west-2',
         'AWS_ACCESS_KEY_ID': 'AWS_ACCESS_KEY_ID',
         'AWS_SECRET_ACCESS_KEY': 'AWS_SECRET_ACCESS_KEY'
     }

--- a/test/fraud_handler_test.py
+++ b/test/fraud_handler_test.py
@@ -1,0 +1,107 @@
+import os
+import boto3
+import json
+import datetime
+import string
+import random
+
+from moto import mock_s3, mock_sts
+from unittest import TestCase
+from testfixtures import LogCapture
+from retrying import retry
+from src import fraud_handler
+
+
+S_INDEX = 'fraud-test-index'
+TODAY = str(datetime.datetime.now())
+LETTERS = string.ascii_lowercase
+RANDOM_STRING = ''.join(random.choice(LETTERS) for i in range(8))
+KEY = 'verify-fraud-events-{}-{}.log'.format(RANDOM_STRING, TODAY)
+BUCKET = 'key-bucket'
+ROLE = 'arn:partition:service:region:account-id:resource'
+
+EVENT_TYPE = 'session_event'
+ISO3359_TIMESTAMP = '2018-02-10T12:00:00Z'
+ORIGINATING_SERVICE = 'test service'
+PID = '26b1e565bb63e7fc3c2ccf4e018f50b84953b02b89d523654034e24a4907d50c'
+REQUEST_ID = '_a217717d-ce3d-407c-88c1-d3d592b6db8c'
+IDP_ENTITY_ID = 'idp entity id'
+TRANSACTION_ENTITY_ID = 'transaction entity id'
+FRAUD_SESSION_EVENT_TYPE = 'fraud_detected'
+GPG45_STATUS = 'AA01'
+
+
+@mock_s3
+@mock_sts
+class FraudHandlerTest(TestCase):
+    __s3_client = None
+    __sts_client = None
+
+    def setUp(self):
+        self.__setup_stub_aws_config()
+
+    def __setup_s3(self):
+        self.__s3_client = boto3.client('s3')
+        self.__s3_client.create_bucket(
+            Bucket=BUCKET,
+        )
+
+    def __setup_sts(self):
+        self.__sts_client = boto3.client('sts')
+        self.__sts_client.assume_role(RoleArn=ROLE, RoleSessionName='Test-assume')
+
+    def __create_fraud_event_string(self, event_id, session_id, fraud_event_id):
+        CONTENT = json.dumps({
+            '_id': {
+                '$oid': event_id
+            },
+            'document': {
+                'eventId': event_id,
+                'eventType': EVENT_TYPE,
+                'timestamp': ISO3359_TIMESTAMP,
+                'originatingService': ORIGINATING_SERVICE,
+                'sessionId': session_id,
+                'details': {
+                    'session_event_type': FRAUD_SESSION_EVENT_TYPE,
+                    'pid': PID,
+                    'request_id': REQUEST_ID,
+                    'idp_entity_id': IDP_ENTITY_ID,
+                    'idp_fraud_event_id': fraud_event_id,
+                    'gpg45_status': GPG45_STATUS
+                }
+            }
+        })
+        return CONTENT
+
+
+    def __write_to_s3(self, BUCKET, KEY):
+        CONTENT = self.__create_fraud_event_string('sample-id-3', 'session-id-3', 'fraud-event-id-1')
+        self.__s3_client.put_object(
+            Bucket=BUCKET,
+            Key=KEY,
+            Body=CONTENT
+        )
+
+
+    def __setup_stub_aws_config(self):
+        os.environ = {
+            'AWS_DEFAULT_REGION': 'us-west-2',
+            'AWS_ACCESS_KEY_ID': 'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY': 'AWS_SECRET_ACCESS_KEY'
+        }
+
+    def test_push_to_s3(self):
+        self.__setup_s3()
+        self.__setup_sts()
+        self.__write_to_s3(BUCKET, KEY)
+        self.key = KEY
+        self.bucket = BUCKET
+        self.role = ROLE
+        self.s_index = S_INDEX
+        self.verify_to_s3 = fraud_handler.VerifyFraudToS3(
+            self.key,
+            self.bucket,
+            self.role,
+            self.s_index,
+        )
+        self.verify_to_s3.push_to_s3(None)

--- a/test/fraud_invoke_test.py
+++ b/test/fraud_invoke_test.py
@@ -1,0 +1,67 @@
+import zipfile
+import io
+import boto3
+from moto import mock_lambda
+import json
+
+def __process_lambda(func_str):
+    zip_output = io.BytesIO()
+    zip_file = zipfile.ZipFile(zip_output, 'w', zipfile.ZIP_DEFLATED)
+    zip_file.writestr('lambda_function.py', func_str)
+    zip_file.close()
+    zip_output.seek(0)
+    return zip_output.read()
+
+
+def zip_test():
+    pfunc = """
+        def fraud_logging_handler(event, context):
+            return event
+    """
+    return __process_lambda(pfunc)
+
+
+@mock_lambda
+def setup_lambda():
+    lambda_client = boto3.client('lambda', 'us-west-2')
+    zip_content = zip_test()
+    lambda_client = boto3.client('lambda', 'us-west-2')
+    lambda_client.create_function(
+        FunctionName='fraud_handler',
+        Runtime='python3.6',
+        Role='test-iam-role',
+        Handler='fraud_logging_handler',
+        Code={
+            'ZipFile': zip_content,
+            },
+        Description='test lambda function',
+        Timeout=3,
+        MemorySize=128,
+        Publish=True,
+    )
+
+    lambda_client.add_permission(
+        FunctionName='fraud_handler',
+        StatementId='1',
+        Action="lambda:InvokeFunction",
+        Principal='432143214321',
+        SourceArn="arn:aws:lambda:us-west-2:account-id:function:helloworld",
+        SourceAccount='123412341234',
+        EventSourceToken='blah',
+        Qualifier='2',
+    )
+
+
+    in_data = {'msg': 'So long and thanks for all the fish'}
+
+#    lambda_client.invoke(
+#        FunctionName='fraud_handler',
+#        InvocationType='Event',
+#        Payload=json.dumps(in_data),
+#    )
+
+    result = lambda_client.list_functions()
+    res = len(result['Functions'])
+    print(res)
+
+# setup_lambda()


### PR DESCRIPTION
What?
-adding fraud logging lambda code, this lambda will be invoked
asyncronously by the event recorder and importer lambda
-adding an s3 mock test for the new fraud logging lambda

Why?
To get the verify fraud logs into Splunk via an S3 Gateway endpoint to
an s3 bucket
The flow would consist of:
Event-Systems Recorder and Importer Lambdas -> invoke -> S3 Fraud
Logging Lambda -> sends events to a cyber s3 bucket via an s3 gateway
endpoint -> SQS trigger -> Forwarders to pull the data from teh s3
bucket and send it to SplunkCloud for indexing.
These events are required in splunk by the Verify Fraud Team, so they
can run detailed analysis on the events.

Pair:
@ronocg <conor.glynn@digital.cabinet-office.gov.uk>
@pritchyspritch <samuel.pritchard@digital.cabinet-office.gov.uk>