### PR TITLE
LbFKGVYc: Fixes to database schema for existing fraud data - Recorder Changes

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -112,6 +112,7 @@ def write_fraud_event_to_database(event, db_connection):
             cursor.execute("""
                 INSERT INTO billing.fraud_events
                 (
+                    event_id,
                     time_stamp,
                     session_id,
                     hashed_persistent_id,
@@ -119,12 +120,12 @@ def write_fraud_event_to_database(event, db_connection):
                     entity_id,
                     fraud_event_id,
                     fraud_indicator,
-                    event_id,
                     transaction_entity_id
                 )
                 VALUES
                 (%s, %s, %s, %s, %s, %s, %s, %s, %s);
             """, [
+                event.event_id,
                 datetime.fromtimestamp(int(event.timestamp) / 1e3),
                 event.session_id,
                 event.details['pid'],
@@ -132,7 +133,6 @@ def write_fraud_event_to_database(event, db_connection):
                 event.details['idp_entity_id'],
                 event.details['idp_fraud_event_id'],
                 event.details['gpg45_status'],
-                event.event_id,
                 event.details['transaction_entity_id']
             ])
     except KeyError as keyError:

--- a/src/database.py
+++ b/src/database.py
@@ -111,9 +111,19 @@ def write_fraud_event_to_database(event, db_connection):
         with RunInTransaction(db_connection) as cursor:
             cursor.execute("""
                 INSERT INTO billing.fraud_events
-                (time_stamp, session_id, hashed_persistent_id, request_id, entity_id, fraud_event_id, fraud_indicator)
+                (
+                    time_stamp,
+                    session_id,
+                    hashed_persistent_id,
+                    request_id,
+                    entity_id,
+                    fraud_event_id,
+                    fraud_indicator,
+                    event_id,
+                    transaction_entity_id
+                )
                 VALUES
-                (%s, %s, %s, %s, %s, %s, %s);
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s);
             """, [
                 datetime.fromtimestamp(int(event.timestamp) / 1e3),
                 event.session_id,
@@ -121,13 +131,21 @@ def write_fraud_event_to_database(event, db_connection):
                 event.details['request_id'],
                 event.details['idp_entity_id'],
                 event.details['idp_fraud_event_id'],
-                event.details['gpg45_status']
+                event.details['gpg45_status'],
+                event.event_id,
+                event.details['transaction_entity_id']
             ])
     except KeyError as keyError:
         getLogger('event-recorder').warning(
             'Failed to store a fraud event [Event ID {0}] due to key error'.format(event.event_id))
         raise keyError
     except IntegrityError as integrityError:
-        getLogger('event-recorder').warning(
-            'Failed to store a fraud event [Event ID {0}] due to integrity error'.format(event.event_id))
-        raise integrityError
+        if integrityError.pgcode == UNIQUE_VIOLATION:
+            # The event has already been recorded - don't throw an exception (no need to retry this message), just
+            # log a notification and move on.
+            getLogger('event-recorder').warning(
+                'Failed to store a fraud event. The Event ID {0} already exists in the database'.format(event.event_id))
+        else:
+            getLogger('event-recorder').warning(
+                'Failed to store a fraud event [Event ID {0}] due to integrity error'.format(event.event_id))
+            raise integrityError

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -81,7 +81,7 @@ class EventHandlerTest(TestCase):
         self.__assert_audit_events_table_has_fraud_event_records(
             [(event_id_3, 'session-id-3', 'fraud-event-id-1'), (event_id_4, 'session-id-4', 'fraud-event-id-2')])
         self.__assert_billing_events_table_has_billing_event_records(
-            [('session-id-1', 'sample-id-1'), ('session-id-2','sample-id-2')])
+            [('session-id-1', 'sample-id-1'), ('session-id-2', 'sample-id-2')])
         self.__assert_fraud_events_table_has_fraud_event_records(
             [(event_id_3, 'session-id-3', 'fraud-event-id-1'), (event_id_4, 'session-id-4', 'fraud-event-id-2')])
         self.assertEqual(self.__number_of_visible_messages(), '0')

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -63,12 +63,14 @@ class EventHandlerTest(TestCase):
 
     def test_reads_messages_from_queue_with_key_from_s3(self):
         self.__setup_s3()
+        event_id_3 = str(uuid.uuid4())
+        event_id_4 = str(uuid.uuid4())
         self.__encrypt_and_send_to_sqs(
             [
                 create_event_string('sample-id-1', 'session-id-1'),
                 create_event_string('sample-id-2', 'session-id-2'),
-                create_fraud_event_string('sample-id-3', 'session-id-3', 'fraud-event-id-1'),
-                create_fraud_event_string('sample-id-4', 'session-id-4', 'fraud-event-id-2'),
+                create_fraud_event_string(event_id_3, 'session-id-3', 'fraud-event-id-1'),
+                create_fraud_event_string(event_id_4, 'session-id-4', 'fraud-event-id-2'),
             ]
         )
 
@@ -77,30 +79,32 @@ class EventHandlerTest(TestCase):
         self.__assert_audit_events_table_has_billing_event_records(
             [('sample-id-1', 'session-id-1'), ('sample-id-2', 'session-id-2')], MINIMUM_LEVEL_OF_ASSURANCE)
         self.__assert_audit_events_table_has_fraud_event_records(
-            [('sample-id-3', 'session-id-3', 'fraud-event-id-1'), ('sample-id-4', 'session-id-4', 'fraud-event-id-2')])
+            [(event_id_3, 'session-id-3', 'fraud-event-id-1'), (event_id_4, 'session-id-4', 'fraud-event-id-2')])
         self.__assert_billing_events_table_has_billing_event_records(
-            [('session-id-1', 'sample-id-1'), ('session-id-2', 'sample-id-2')])
+            [('session-id-1', 'sample-id-1'), ('session-id-2','sample-id-2')])
         self.__assert_fraud_events_table_has_fraud_event_records(
-            [('session-id-3', 'fraud-event-id-1'), ('session-id-4', 'fraud-event-id-2')])
+            [(event_id_3, 'session-id-3', 'fraud-event-id-1'), (event_id_4, 'session-id-4', 'fraud-event-id-2')])
         self.assertEqual(self.__number_of_visible_messages(), '0')
         self.assertEqual(self.__number_of_hidden_messages(), '0')
 
     def test_reads_fraud_events_from_queue(self):
         self.__setup_s3()
+        event_id_1 = str(uuid.uuid4())
+        event_id_2 = str(uuid.uuid4())
         self.__encrypt_and_send_to_sqs(
             [
-                create_fraud_event_string('sample-id-1', 'session-id-1', 'fraud-event-id-1'),
-                create_fraud_event_string('sample-id-2', 'session-id-2', 'fraud-event-id-2'),
+                create_fraud_event_string(event_id_1, 'session-id-1', 'fraud-event-id-1'),
+                create_fraud_event_string(event_id_2, 'session-id-2', 'fraud-event-id-2'),
             ]
         )
 
         event_handler.store_queued_events(None, None)
 
         self.__assert_audit_events_table_has_fraud_event_records(
-            [('sample-id-1', 'session-id-1', 'fraud-event-id-1'), ('sample-id-2', 'session-id-2', 'fraud-event-id-2')])
+            [(event_id_1, 'session-id-1', 'fraud-event-id-1'), (event_id_2, 'session-id-2', 'fraud-event-id-2')])
         self.__assert_billing_events_table_has_no_billing_event_records
         self.__assert_fraud_events_table_has_fraud_event_records(
-            [('session-id-1', 'fraud-event-id-1'), ('session-id-2', 'fraud-event-id-2')])
+            [(event_id_1, 'session-id-1', 'fraud-event-id-1'), (event_id_2, 'session-id-2', 'fraud-event-id-2')])
         self.assertEqual(self.__number_of_visible_messages(), '0')
         self.assertEqual(self.__number_of_hidden_messages(), '0')
 
@@ -444,22 +448,24 @@ class EventHandlerTest(TestCase):
                         request_id,
                         entity_id,
                         fraud_event_id,
-                        fraud_indicator
+                        fraud_indicator,
+                        transaction_entity_id
                     FROM
                         billing.fraud_events
                     WHERE
-                        session_id = %s;
+                        event_id = %s;
                 """, [fraud_event[0]])
                 matching_records = cursor.fetchone()
 
             self.assertIsNotNone(matching_records)
             self.assertEqual(matching_records[0], datetime.fromtimestamp(TIMESTAMP / 1e3))
-            self.assertEqual(matching_records[1], fraud_event[0])
+            self.assertEqual(matching_records[1], fraud_event[1])
             self.assertEqual(matching_records[2], PID)
             self.assertEqual(matching_records[3], REQUEST_ID)
             self.assertEqual(matching_records[4], IDP_ENTITY_ID)
-            self.assertEqual(matching_records[5], fraud_event[1])
+            self.assertEqual(matching_records[5], fraud_event[2])
             self.assertEqual(matching_records[6], GPG45_STATUS)
+            self.assertEqual(matching_records[7], TRANSACTION_ENTITY_ID)
 
     def __setup_db_connection_string(self, password_in_env=False):
         if password_in_env:
@@ -572,7 +578,8 @@ def create_fraud_event_string(event_id, session_id, fraud_event_id):
             'request_id': REQUEST_ID,
             'idp_entity_id': IDP_ENTITY_ID,
             'idp_fraud_event_id': fraud_event_id,
-            'gpg45_status': GPG45_STATUS
+            'gpg45_status': GPG45_STATUS,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID
         }
     })
 
@@ -589,6 +596,7 @@ def create_fraud_event_without_idp_fraud_event_id_string(event_id, session_id):
             'pid': PID,
             'request_id': REQUEST_ID,
             'idp_entity_id': IDP_ENTITY_ID,
-            'gpg45_status': GPG45_STATUS
+            'gpg45_status': GPG45_STATUS,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID
         }
     })

--- a/test/import_handler_test.py
+++ b/test/import_handler_test.py
@@ -373,7 +373,8 @@ class ImportHandlerTest(TestCase):
                     'request_id': REQUEST_ID,
                     'idp_entity_id': IDP_ENTITY_ID,
                     'idp_fraud_event_id': fraud_event_id,
-                    'gpg45_status': GPG45_STATUS
+                    'gpg45_status': GPG45_STATUS,
+                    'transaction_entity_id': TRANSACTION_ENTITY_ID
                 }
             }
         })


### PR DESCRIPTION
## What

As a developer, I want to be able to join between data in the `billing.fraud_events` table and the more detailed information in the `audit_events` table.

* For consistency with billing events, the primary key should be event ID
* Add the `transaction_entity_id` to fraud_events also

## Dependencies

https://github.com/alphagov/verify-event-system-database-scripts/pull/41

## How

Change `write_fraud_event_to_database()` to also insert `event_id` and `transaction_entity_id` from the original event.