### PR TITLE
YYdbmOjj: lambda to process the data thats uploaded and put it into the database

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,3 +4,4 @@ flake8==3.6.0
 moto==1.3.7
 testfixtures==5.4.0
 retrying==1.3.3
+parameterized==0.7.0

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,2 +1,3 @@
 psycopg2-binary==2.7.4
 cryptography==2.3.1
+dateparser==0.7.2

--- a/src/common.py
+++ b/src/common.py
@@ -1,0 +1,14 @@
+import os
+import boto3
+
+from src.kms import decrypt
+from psycopg2.extensions import parse_dsn
+
+
+def get_database_password(dsn):
+    if 'ENCRYPTED_DATABASE_PASSWORD' in os.environ:
+        # boto returns decrypted as b'bytes' so decode to convert to password string
+        return decrypt(os.environ['ENCRYPTED_DATABASE_PASSWORD']).decode()
+    else:
+        dsn_components = parse_dsn(dsn)
+        return boto3.client('rds').generate_db_auth_token(dsn_components['host'], 5432, dsn_components['user'])

--- a/src/database.py
+++ b/src/database.py
@@ -237,7 +237,21 @@ def write_idp_fraud_event_to_database(session, idp_fraud_event, db_connection):
             ])
 
             result = cursor.fetchone()
-            return result[0];
+            id = result[0];
+
+            for contra_indicator in idp_fraud_event.contra_indicators:
+                cursor.execute("""
+                    INSERT INTO idp_data.idp_fraud_event_contraindicators
+                    (
+                        idp_fraud_events_id,
+                        contraindicator_code
+                    )
+                    VALUES
+                    (
+                        %s,
+                        %s
+                    )
+                """, [id, contra_indicator])
 
     except KeyError as keyError:
         getLogger('event-recorder').warning(

--- a/src/database.py
+++ b/src/database.py
@@ -226,6 +226,7 @@ def write_idp_fraud_event_to_database(upload_session, idp_fraud_event, cursor, l
                       FROM billing.fraud_events
                      WHERE fraud_event_id = %(idp_event_id)s
                        AND entity_id = %(idp_entity_id)s
+                     LIMIT 1
                 ),
                 %(session_id)s
              )

--- a/src/database.py
+++ b/src/database.py
@@ -182,19 +182,17 @@ def write_import_session(upload_session, db_connection, logger):
             return upload_session
 
     except KeyError as keyError:
-        logger.warning(
-            'Failed to store upload session {} due to key error'.format(upload_session.id))
+        logger.exception(
+            'Failed to store upload session for file {}, idp = {} due to key error'.format(
+                upload_session.source_file_name, upload_session.idp_entity_id)
+        )
         raise keyError
     except IntegrityError as integrityError:
-        if integrityError.pgcode == UNIQUE_VIOLATION:
-            # The event has already been recorded - don't throw an exception (no need to retry this message), just
-            # log a notification and move on.
-            logger.warning(
-                'Failed to store a upload session. The ID {0} already exists in the database'.format(upload_session.id))
-        else:
-            logger.warning(
-                'Failed to store a upload session [ID {0}] due to integrity error'.format(upload_session.id))
-            raise integrityError
+        logger.exception(
+            'Failed to store upload session for file {}, idp = {} due to integrity error'.format(
+                upload_session.source_file_name, upload_session.idp_entity_id)
+        )
+        raise integrityError
 
 
 def write_idp_fraud_event_to_database(upload_session, idp_fraud_event, db_connection, logger):
@@ -269,25 +267,16 @@ def write_idp_fraud_event_to_database(upload_session, idp_fraud_event, db_connec
             return result[1]
 
     except KeyError as keyError:
-        logger.warning(
+        logger.exception(
             'Failed to store an IDP fraud event [Event ID {}] due to key error'.format(idp_fraud_event.idp_event_id))
         raise keyError
     except IntegrityError as integrityError:
-        if integrityError.pgcode == UNIQUE_VIOLATION:
-            # The event has already been recorded - don't throw an exception (no need to retry this message), just
-            # log a notification and move on.
-            logger.warning(
-                'Failed to store an IDP fraud event. The Event ID {} already exists in the database'.format(
-                    idp_fraud_event.idp_event_id
-                )
+        logger.exception(
+            'Failed to store an IDP fraud event [Event ID {}] due to integrity error'.format(
+                idp_fraud_event.idp_event_id
             )
-        else:
-            logger.warning(
-                'Failed to store an IDP fraud event [Event ID {}] due to integrity error'.format(
-                    idp_fraud_event.idp_event_id
-                )
-            )
-            raise integrityError
+        )
+        raise integrityError
 
 
 def update_session_as_validated(upload_session, db_connection):

--- a/src/database.py
+++ b/src/database.py
@@ -224,7 +224,12 @@ def write_idp_fraud_event_to_database(upload_session, idp_fraud_event, db_connec
                     %(pid)s,
                     %(client_ip_address)s,
                     %(contra_score)s,
-                    (SELECT event_id FROM billing.fraud_events WHERE fraud_event_id = %(idp_event_id)s AND entity_id = %(idp_entity_id)s),
+                    (
+                        SELECT event_id
+                          FROM billing.fraud_events
+                         WHERE fraud_event_id = %(idp_event_id)s
+                           AND entity_id = %(idp_entity_id)s
+                    ),
                     %(session_id)s
                  )
                  ON CONFLICT (idp_entity_id, idp_event_id)
@@ -272,10 +277,16 @@ def write_idp_fraud_event_to_database(upload_session, idp_fraud_event, db_connec
             # The event has already been recorded - don't throw an exception (no need to retry this message), just
             # log a notification and move on.
             logger.warning(
-                'Failed to store an IDP fraud event. The Event ID {} already exists in the database'.format(idp_fraud_event.idp_event_id))
+                'Failed to store an IDP fraud event. The Event ID {} already exists in the database'.format(
+                    idp_fraud_event.idp_event_id
+                )
+            )
         else:
             logger.warning(
-                'Failed to store an IDP fraud event [Event ID {}] due to integrity error'.format(idp_fraud_event.idp_event_id))
+                'Failed to store an IDP fraud event [Event ID {}] due to integrity error'.format(
+                    idp_fraud_event.idp_event_id
+                )
+            )
             raise integrityError
 
 

--- a/src/database.py
+++ b/src/database.py
@@ -212,29 +212,29 @@ def write_idp_fraud_event_to_database(session, idp_fraud_event, db_connection):
                  )
                  VALUES
                  (
-                    %s,
-                    %s,
-                    %s,
-                    %s,
-                    %s,
-                    %s,
-                    %s,
-                    %s,
-                    NULL,
-                    %s
+                    %(idp_entity_id)s,
+                    %(idp_event_id)s,
+                    %(timestamp)s,
+                    %(fid_code)s,
+                    %(request_id)s,
+                    %(pid)s,
+                    %(client_ip_address)s,
+                    %(contra_score)s,
+                    (SELECT event_id FROM billing.fraud_events WHERE fraud_event_id = %(idp_event_id)s AND entity_id = %(idp_entity_id)s),
+                    %(session_id)s
                  )
                  RETURNING id
-             """, [
-                idp_fraud_event.idp_entity_id,
-                idp_fraud_event.idp_event_id,
-                idp_fraud_event.timestamp,
-                idp_fraud_event.fid_code,
-                idp_fraud_event.request_id,
-                idp_fraud_event.pid,
-                idp_fraud_event.client_ip_address,
-                idp_fraud_event.contra_score,
-                session
-            ])
+             """, {
+                "idp_entity_id": idp_fraud_event.idp_entity_id,
+                "idp_event_id": idp_fraud_event.idp_event_id,
+                "timestamp": idp_fraud_event.timestamp,
+                "fid_code": idp_fraud_event.fid_code,
+                "request_id": idp_fraud_event.request_id,
+                "pid": idp_fraud_event.pid,
+                "client_ip_address": idp_fraud_event.client_ip_address,
+                "contra_score": idp_fraud_event.contra_score,
+                "session_id": session
+            })
 
             result = cursor.fetchone()
             id = result[0];

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -3,6 +3,7 @@ import os
 
 import boto3
 
+from src.common import get_database_password
 from src.database import create_db_connection, write_audit_event_to_database, \
     write_billing_event_to_database, write_fraud_event_to_database
 from src.decryption import decrypt_message
@@ -10,7 +11,6 @@ from src.event_mapper import event_from_json
 from src.kms import decrypt
 from src.s3 import fetch_decryption_key
 from src.sqs import fetch_single_message, delete_message
-from src.common import get_database_password
 
 
 # noinspection PyUnusedLocal

--- a/src/idp_fraud_data_handler.py
+++ b/src/idp_fraud_data_handler.py
@@ -35,39 +35,36 @@ def process_file(bucket, filename, upload_session, db_connection,
     logger.info('Processing data for IDP {}'.format(upload_session.idp_entity_id))
 
     temp_file = download_import_file(bucket, filename)
-    with open(temp_file, newline='') as csvfile:
-        reader = csv.reader(csvfile, dialect=dialect)
-        errors_occurred = False
-        skip_row = has_header
-        row_number = 0
-        try:
-            with RunInTransaction(db_connection) as cursor:
-                for row in reader:
-                    row_number = row_number + 1
-                    if skip_row:
-                        skip_row = False
-                        continue
+    try:
+        with open(temp_file, newline='') as csvfile:
+            reader = csv.reader(csvfile, dialect=dialect)
+            errors_occurred = False
+            skip_row = has_header
+            row_number = 0
+            try:
+                with RunInTransaction(db_connection) as cursor:
+                    for row in reader:
+                        row_number = row_number + 1
+                        if skip_row:
+                            skip_row = False
+                            continue
 
-                    idp_fraud_event = parse_line(row, upload_session.idp_entity_id, timezone)
-                    event_id = write_idp_fraud_event_to_database(upload_session, idp_fraud_event, cursor, logger)
-                    if event_id:
-                        logger.info(
-                            'Successfully wrote IDP fraud event ID {} to database and '
-                            'found matching fraud event {}'.format(idp_fraud_event.idp_event_id, event_id)
-                        )
-                    else:
-                        logger.warning(
-                            'Successfully wrote IDP fraud event ID {} to database BUT '
-                            'no matching fraud event found'.format(idp_fraud_event.idp_event_id)
-                        )
+                        idp_fraud_event = parse_line(row, upload_session.idp_entity_id, timezone)
+                        id = write_idp_fraud_event_to_database(upload_session, idp_fraud_event, cursor, logger)
+                        if id:
+                            logger.info(
+                                'Successfully wrote IDP fraud event ID {} to database.'.format(idp_fraud_event.idp_event_id)
+                            )
 
-        except Exception as exception:
-            message = 'Failed to store IDP fraud event: {} (line {})'.format(exception, row_number)
-            logger.exception(message)
-            write_upload_error(upload_session, row_number, '**Row Exception**', message, db_connection)
-            errors_occurred = True
+            except Exception as exception:
+                message = 'Failed to store IDP fraud event: {} (line {})'.format(exception, row_number)
+                logger.exception(message)
+                write_upload_error(upload_session, row_number, '**Row Exception**', message, db_connection)
+                errors_occurred = True
 
-    os.remove(temp_file)
+    finally:
+        os.remove(temp_file)
+
     return not errors_occurred
 
 

--- a/src/idp_fraud_data_handler.py
+++ b/src/idp_fraud_data_handler.py
@@ -1,0 +1,97 @@
+import logging
+import os
+import boto3
+import csv
+import codecs
+
+from src.database import create_db_connection, write_import_session
+from src.s3 import fetch_import_file, fetch_object_tags, delete_import_file
+from src.kms import decrypt
+from src.idp_fraud_event import IdpFraudEvent
+from psycopg2.extensions import parse_dsn
+
+logger = logging.getLogger('idp_fraud_data_handler')
+logger.setLevel(logging.INFO)
+
+
+def create_import_session(bucket, filename, db_connection):
+    tags = fetch_object_tags(bucket, filename)
+    idp_entity_id = tags['idp']
+    username = tags['username']
+    return write_import_session(filename, idp_entity_id, username, db_connection)
+
+
+def process_file(bucket, filename, session, idp_entity_id, db_connection):
+    iterable = fetch_import_file(bucket, filename)
+    reader = csv.reader(codecs.iterdecode(iterable, 'utf-8'), dialect="excel")
+    errors_occurred = False
+
+    for row in reader:
+        try:
+            fraud_event = parse_line(row, idp_entity_id)
+            store_event(session, fraud_event, db_connection)
+
+        except Exception as exception:
+            message = 'Failed to store message {}'.format(exception)
+            logger.exception(message)
+            write_to_error_log(session, message)
+            errors_occurred = True
+
+    return not errors_occurred
+
+
+def parse_line(row, idp_entity_id):
+    return IdpFraudEvent(
+        idp_entity_id=idp_entity_id,
+        timestamp=row[0],
+        idp_event_id=row[1],
+        fid_code=row[2],
+        contra_indicators=row[3].split(","),
+        contra_score=row[4],
+        request_id=row[5],
+        client_ip_address=row[6],
+        pid=row[7]
+    )
+
+
+def write_to_error_log(session, message):
+    pass
+
+
+def move_to_error(bucket, filename):
+    pass
+
+
+def move_to_success(bucket, filename):
+    delete_import_file(bucket, filename)
+
+
+def store_event(session, fraud_event, db_connection):
+    pass
+
+
+def idp_fraud_data_events(event, __):
+    dsn = os.environ['DB_CONNECTION_STRING']
+
+    database_password = None
+    if 'ENCRYPTED_DATABASE_PASSWORD' in os.environ:
+        # boto returns decrypted as b'bytes' so decode to convert to password string
+        database_password = decrypt(os.environ['ENCRYPTED_DATABASE_PASSWORD']).decode()
+    else:
+        dsn_components = parse_dsn(dsn)
+        database_password = boto3.client('rds').generate_db_auth_token(
+            dsn_components['host'], 5432, dsn_components['user'])
+
+    db_connection = create_db_connection(dsn, database_password)
+    logger.info('Created connection to DB')
+
+    for record in event['Records']:
+        bucket = record['s3']['bucket']['name']
+        filename = record['s3']['object']['key']
+
+        session, idp_entity_id = create_import_session(bucket, filename, db_connection)
+
+        if process_file(bucket, filename, session, idp_entity_id, db_connection):
+            move_to_success(bucket, filename)
+        else:
+            move_to_error(bucket, filename)

--- a/src/idp_fraud_data_handler.py
+++ b/src/idp_fraud_data_handler.py
@@ -69,6 +69,7 @@ def process_file(bucket, filename, upload_session, db_connection,
                 write_upload_error(upload_session, row_number, '**Row Exception**', message, db_connection)
                 errors_occurred = True
 
+    os.remove(temp_file)
     return not errors_occurred
 
 

--- a/src/idp_fraud_data_handler.py
+++ b/src/idp_fraud_data_handler.py
@@ -23,6 +23,7 @@ def create_import_session(bucket, filename, db_connection):
 
 
 def process_file(bucket, filename, session, idp_entity_id, db_connection, skip_header=True):
+    logger.info('Processing data for IDP {}'.format(idp_entity_id))
     iterable = fetch_import_file(bucket, filename)
     reader = csv.reader(codecs.iterdecode(iterable, 'utf-8'), dialect="excel")
     errors_occurred = False
@@ -35,6 +36,7 @@ def process_file(bucket, filename, session, idp_entity_id, db_connection, skip_h
         try:
             idp_fraud_event = parse_line(row, idp_entity_id)
             write_idp_fraud_event_to_database(session, idp_fraud_event, db_connection)
+            logger.info('Successfully wrote IDP fraud event ID {} to database'.format(idp_fraud_event.idp_event_id))
 
         except Exception as exception:
             message = 'Failed to store message {}'.format(exception)

--- a/src/idp_fraud_event.py
+++ b/src/idp_fraud_event.py
@@ -17,4 +17,7 @@ class IdpFraudEvent(object):
         self.pid = pid
         self.client_ip_address = client_ip_address
         self.contra_score = contra_score
-        self.contra_indicators = contra_indicators
+        if contra_indicators:
+            self.contra_indicators = contra_indicators
+        else:
+            self.contra_indicators = []

--- a/src/idp_fraud_event.py
+++ b/src/idp_fraud_event.py
@@ -1,0 +1,22 @@
+class IdpFraudEvent(object):
+    def __init__(self,
+                 idp_entity_id,
+                 idp_event_id,
+                 timestamp,
+                 fid_code,
+                 request_id,
+                 pid,
+                 client_ip_address,
+                 contra_score,
+                 contra_indicators=[]):
+        self.idp_entity_id = idp_entity_id
+        self.idp_event_id = idp_event_id
+        self.timestamp = timestamp
+        self.fid_code = fid_code
+        self.request_id = request_id
+        self.pid = pid
+        self.client_ip_address = client_ip_address
+        self.contra_score = contra_score
+        self.contra_indicators = contra_indicators
+
+

--- a/src/idp_fraud_event.py
+++ b/src/idp_fraud_event.py
@@ -18,5 +18,3 @@ class IdpFraudEvent(object):
         self.client_ip_address = client_ip_address
         self.contra_score = contra_score
         self.contra_indicators = contra_indicators
-
-

--- a/src/import_handler.py
+++ b/src/import_handler.py
@@ -1,14 +1,12 @@
+import json
 import logging
 import os
-import json
-import boto3
 
+from src.common import get_database_password
 from src.database import create_db_connection, write_audit_event_to_database, \
     write_billing_event_to_database, write_fraud_event_to_database
 from src.event_mapper import event_from_json_object
 from src.s3 import fetch_import_file, delete_import_file
-from src.kms import decrypt
-from src.common import get_database_password
 
 
 def import_events(event, __):

--- a/src/s3.py
+++ b/src/s3.py
@@ -19,9 +19,12 @@ def fetch_import_file(bucket_name, filename):
 
 
 def download_import_file(bucket_name, filename):
-    temp_file_name = tempfile.mktemp()
     s3_client = boto3.client('s3')
-    s3_client.download_file(bucket_name, filename, temp_file_name)
+    fd, temp_file_name = tempfile.mkstemp()
+    with open(temp_file_name, 'wb') as data:
+        s3_client.download_fileobj(bucket_name, filename, data)
+
+    os.close(fd)
     return temp_file_name
 
 

--- a/src/s3.py
+++ b/src/s3.py
@@ -42,5 +42,7 @@ def move_file(bucket_name, filename, new_prefix):
 
     s3_client.copy_object(Bucket=bucket_name,
                           CopySource=f'{bucket_name}/{filename}',
-                          Key=f'{new_prefix}/{new_filename}')
+                          Key=f'{new_prefix}/{new_filename}',
+                          TaggingDirective="COPY",
+                          ServerSideEncryption="AES256")
     s3_client.delete_object(Bucket=bucket_name, Key=filename)

--- a/src/s3.py
+++ b/src/s3.py
@@ -19,3 +19,9 @@ def fetch_import_file(bucket_name, filename):
 def delete_import_file(bucket_name, filename):
     s3_client = boto3.client('s3')
     s3_client.delete_object(Bucket=bucket_name, Key=filename)
+
+
+def fetch_object_tags(bucket_name, filename):
+    s3_client = boto3.client('s3')
+    response = s3_client.get_object_tagging(Bucket=bucket_name, Key=filename)
+    return {tag['Key']: tag['Value'] for tag in response['TagSet']}

--- a/src/s3.py
+++ b/src/s3.py
@@ -25,3 +25,11 @@ def fetch_object_tags(bucket_name, filename):
     s3_client = boto3.client('s3')
     response = s3_client.get_object_tagging(Bucket=bucket_name, Key=filename)
     return {tag['Key']: tag['Value'] for tag in response['TagSet']}
+
+
+def move_file(bucket_name, filename, new_prefix):
+    s3_client = boto3.client('s3')
+    new_filename = os.path.basename(filename)
+
+    s3_client.copy_object(Bucket=bucket_name, CopySource=f'{bucket_name}/{filename}', Key=f'{new_prefix}/{new_filename}')
+    s3_client.delete_object(Bucket=bucket_name, Key=filename)

--- a/src/s3.py
+++ b/src/s3.py
@@ -1,6 +1,6 @@
 import boto3
 import os
-
+import logging
 
 def fetch_decryption_key():
     s3_client = boto3.client('s3')

--- a/src/s3.py
+++ b/src/s3.py
@@ -1,6 +1,8 @@
-import boto3
 import os
-import logging
+import tempfile
+
+import boto3
+
 
 def fetch_decryption_key():
     s3_client = boto3.client('s3')
@@ -14,6 +16,13 @@ def fetch_import_file(bucket_name, filename):
     s3_client = boto3.client('s3')
     response = s3_client.get_object(Bucket=bucket_name, Key=filename)
     return response['Body'].iter_lines()
+
+
+def download_import_file(bucket_name, filename):
+    temp_file_name = tempfile.mktemp()
+    s3_client = boto3.client('s3')
+    s3_client.download_file(bucket_name, filename, temp_file_name)
+    return temp_file_name
 
 
 def delete_import_file(bucket_name, filename):
@@ -31,5 +40,7 @@ def move_file(bucket_name, filename, new_prefix):
     s3_client = boto3.client('s3')
     new_filename = os.path.basename(filename)
 
-    s3_client.copy_object(Bucket=bucket_name, CopySource=f'{bucket_name}/{filename}', Key=f'{new_prefix}/{new_filename}')
+    s3_client.copy_object(Bucket=bucket_name,
+                          CopySource=f'{bucket_name}/{filename}',
+                          Key=f'{new_prefix}/{new_filename}')
     s3_client.delete_object(Bucket=bucket_name, Key=filename)

--- a/src/upload_session.py
+++ b/src/upload_session.py
@@ -1,5 +1,6 @@
 import datetime
 
+
 class UploadSession(object):
     def __init__(self,
                  id=0,

--- a/src/upload_session.py
+++ b/src/upload_session.py
@@ -1,0 +1,20 @@
+import datetime
+
+class UploadSession(object):
+    def __init__(self,
+                 id=0,
+                 time_stamp=None,
+                 source_file_name=None,
+                 idp_entity_id=None,
+                 userid=None,
+                 passed_validation=False):
+        self.id = id
+        if time_stamp:
+            self.time_stamp = time_stamp
+        else:
+            self.time_stamp = datetime.datetime.now()
+
+        self.source_file_name = source_file_name
+        self.idp_entity_id = idp_entity_id
+        self.userid = userid
+        self.passed_validation = passed_validation

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -1,18 +1,24 @@
-import os
-import boto3
 import base64
+import os
 import uuid
+from datetime import datetime
+from unittest import TestCase
+
+import boto3
 import psycopg2
 from moto import mock_sqs, mock_s3, mock_kms
-from unittest import TestCase
-from datetime import datetime
-from testfixtures import LogCapture
 from retrying import retry
+from testfixtures import LogCapture
 
 from src import event_handler
 from src.database import RunInTransaction
+from test.helpers import setup_stub_aws_config, clean_db, create_event_string, create_fraud_event_string, \
+    MINIMUM_LEVEL_OF_ASSURANCE, ENCRYPTION_KEY, create_billing_event_without_minimum_level_of_assurance_string, \
+    create_fraud_event_without_idp_fraud_event_id_string, EVENT_TYPE, TIMESTAMP, ORIGINATING_SERVICE, \
+    SESSION_EVENT_TYPE, TRANSACTION_ENTITY_ID, FRAUD_SESSION_EVENT_TYPE, DB_PASSWORD, \
+    PID, REQUEST_ID, IDP_ENTITY_ID, PROVIDED_LEVEL_OF_ASSURANCE, REQUIRED_LEVEL_OF_ASSURANCE, GPG45_STATUS
 from test.test_encrypter import encrypt_string
-from test.helpers import *
+
 
 @mock_sqs
 @mock_s3

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -1,7 +1,6 @@
 import os
 import boto3
 import base64
-import json
 import uuid
 import psycopg2
 from moto import mock_sqs, mock_s3, mock_kms
@@ -13,23 +12,7 @@ from retrying import retry
 from src import event_handler
 from src.database import RunInTransaction
 from test.test_encrypter import encrypt_string
-
-EVENT_TYPE = 'session_event'
-TIMESTAMP = 1518264452000  # '2018-02-10 12:07:32'
-ORIGINATING_SERVICE = 'test service'
-ENCRYPTION_KEY = b'sixteen byte key'
-DB_PASSWORD = 'secretPassword'
-SESSION_EVENT_TYPE = 'idp_authn_succeeded'
-PID = '26b1e565bb63e7fc3c2ccf4e018f50b84953b02b89d523654034e24a4907d50c'
-REQUEST_ID = '_a217717d-ce3d-407c-88c1-d3d592b6db8c'
-IDP_ENTITY_ID = 'idp entity id'
-TRANSACTION_ENTITY_ID = 'transaction entity id'
-MINIMUM_LEVEL_OF_ASSURANCE = 'LEVEL_2'
-PROVIDED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
-REQUIRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
-FRAUD_SESSION_EVENT_TYPE = 'fraud_detected'
-GPG45_STATUS = 'AA01'
-
+from test.helpers import *
 
 @mock_sqs
 @mock_s3
@@ -59,7 +42,7 @@ class EventHandlerTest(TestCase):
         self.__setup_sqs()
 
     def tearDown(self):
-        self.__clean_db()
+        clean_db(self.db_connection)
 
     def test_reads_messages_from_queue_with_key_from_s3(self):
         self.__setup_s3()
@@ -295,14 +278,6 @@ class EventHandlerTest(TestCase):
         )
         return response['Attributes'][attribute]
 
-    def __clean_db(self):
-        with RunInTransaction(self.db_connection) as cursor:
-            cursor.execute("""
-                DELETE FROM audit.audit_events;
-                DELETE FROM billing.billing_events;
-                DELETE FROM billing.fraud_events;
-            """)
-
     def __assert_audit_events_table_has_billing_event_records(self, expected_events, minimum_level_of_assurance):
         for event in expected_events:
             with RunInTransaction(self.db_connection) as cursor:
@@ -516,87 +491,3 @@ class EventHandlerTest(TestCase):
         )
         os.environ['DECRYPTION_KEY_BUCKET_NAME'] = bucket_name
         os.environ['DECRYPTION_KEY_FILE_NAME'] = filename
-
-
-def setup_stub_aws_config():
-    os.environ = {
-        'AWS_DEFAULT_REGION': 'eu-west-2',
-        'AWS_ACCESS_KEY_ID': 'AWS_ACCESS_KEY_ID',
-        'AWS_SECRET_ACCESS_KEY': 'AWS_SECRET_ACCESS_KEY'
-    }
-
-
-def create_event_string(event_id, session_id):
-    return json.dumps({
-        'eventId': event_id,
-        'eventType': EVENT_TYPE,
-        'timestamp': TIMESTAMP,
-        'originatingService': ORIGINATING_SERVICE,
-        'sessionId': session_id,
-        'details': {
-            'session_event_type': SESSION_EVENT_TYPE,
-            'pid': PID,
-            'request_id': REQUEST_ID,
-            'idp_entity_id': IDP_ENTITY_ID,
-            'transaction_entity_id': TRANSACTION_ENTITY_ID,
-            'minimum_level_of_assurance': MINIMUM_LEVEL_OF_ASSURANCE,
-            'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
-            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
-        }
-    })
-
-
-def create_billing_event_without_minimum_level_of_assurance_string(event_id, session_id):
-    return json.dumps({
-        'eventId': event_id,
-        'eventType': EVENT_TYPE,
-        'timestamp': TIMESTAMP,
-        'originatingService': ORIGINATING_SERVICE,
-        'sessionId': session_id,
-        'details': {
-            'session_event_type': SESSION_EVENT_TYPE,
-            'pid': PID,
-            'request_id': REQUEST_ID,
-            'idp_entity_id': IDP_ENTITY_ID,
-            'transaction_entity_id': TRANSACTION_ENTITY_ID,
-            'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
-            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
-        }
-    })
-
-
-def create_fraud_event_string(event_id, session_id, fraud_event_id):
-    return json.dumps({
-        'eventId': event_id,
-        'eventType': EVENT_TYPE,
-        'timestamp': TIMESTAMP,
-        'originatingService': ORIGINATING_SERVICE,
-        'sessionId': session_id,
-        'details': {
-            'session_event_type': FRAUD_SESSION_EVENT_TYPE,
-            'pid': PID,
-            'request_id': REQUEST_ID,
-            'idp_entity_id': IDP_ENTITY_ID,
-            'idp_fraud_event_id': fraud_event_id,
-            'gpg45_status': GPG45_STATUS,
-            'transaction_entity_id': TRANSACTION_ENTITY_ID
-        }
-    })
-
-
-def create_fraud_event_without_idp_fraud_event_id_string(event_id, session_id):
-    return json.dumps({
-        'eventId': event_id,
-        'eventType': EVENT_TYPE,
-        'timestamp': TIMESTAMP,
-        'originatingService': ORIGINATING_SERVICE,
-        'sessionId': session_id,
-        'details': {
-            'session_event_type': FRAUD_SESSION_EVENT_TYPE,
-            'pid': PID,
-            'request_id': REQUEST_ID,
-            'idp_entity_id': IDP_ENTITY_ID,
-            'gpg45_status': GPG45_STATUS,
-            'transaction_entity_id': TRANSACTION_ENTITY_ID
-        }
-    })

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,116 @@
+import json
+import os
+from src.database import RunInTransaction
+
+EVENT_TYPE = 'session_event'
+TIMESTAMP = 1518264452000  # '2018-02-10 12:07:32'
+ORIGINATING_SERVICE = 'test service'
+ENCRYPTION_KEY = b'sixteen byte key'
+DB_PASSWORD = 'secretPassword'
+SESSION_EVENT_TYPE = 'idp_authn_succeeded'
+PID = '26b1e565bb63e7fc3c2ccf4e018f50b84953b02b89d523654034e24a4907d50c'
+REQUEST_ID = '_a217717d-ce3d-407c-88c1-d3d592b6db8c'
+IDP_ENTITY_ID = 'idp entity id'
+TRANSACTION_ENTITY_ID = 'transaction entity id'
+MINIMUM_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+PROVIDED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+REQUIRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+FRAUD_SESSION_EVENT_TYPE = 'fraud_detected'
+GPG45_STATUS = 'AA01'
+
+
+def clean_db(db_connection):
+    with RunInTransaction(db_connection) as cursor:
+        cursor.execute("""
+            DELETE FROM idp_data.idp_fraud_event_contraindicators;
+            DELETE FROM idp_data.idp_fraud_events;
+            DELETE FROM idp_data.upload_session_validation_failures;
+            DELETE FROM idp_data.upload_sessions;
+            DELETE FROM billing.fraud_events;
+            DELETE FROM billing.billing_events;
+            DELETE FROM audit.audit_events;
+        """)
+
+
+def setup_stub_aws_config():
+    os.environ = {
+        'AWS_DEFAULT_REGION': 'eu-west-2',
+        'AWS_ACCESS_KEY_ID': 'AWS_ACCESS_KEY_ID',
+        'AWS_SECRET_ACCESS_KEY': 'AWS_SECRET_ACCESS_KEY'
+    }
+
+
+def create_event_string(event_id, session_id):
+    return json.dumps({
+        'eventId': event_id,
+        'eventType': EVENT_TYPE,
+        'timestamp': TIMESTAMP,
+        'originatingService': ORIGINATING_SERVICE,
+        'sessionId': session_id,
+        'details': {
+            'session_event_type': SESSION_EVENT_TYPE,
+            'pid': PID,
+            'request_id': REQUEST_ID,
+            'idp_entity_id': IDP_ENTITY_ID,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID,
+            'minimum_level_of_assurance': MINIMUM_LEVEL_OF_ASSURANCE,
+            'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
+            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
+        }
+    })
+
+
+def create_billing_event_without_minimum_level_of_assurance_string(event_id, session_id):
+    return json.dumps({
+        'eventId': event_id,
+        'eventType': EVENT_TYPE,
+        'timestamp': TIMESTAMP,
+        'originatingService': ORIGINATING_SERVICE,
+        'sessionId': session_id,
+        'details': {
+            'session_event_type': SESSION_EVENT_TYPE,
+            'pid': PID,
+            'request_id': REQUEST_ID,
+            'idp_entity_id': IDP_ENTITY_ID,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID,
+            'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
+            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
+        }
+    })
+
+
+def create_fraud_event_string(event_id, session_id, fraud_event_id):
+    return json.dumps({
+        'eventId': event_id,
+        'eventType': EVENT_TYPE,
+        'timestamp': TIMESTAMP,
+        'originatingService': ORIGINATING_SERVICE,
+        'sessionId': session_id,
+        'details': {
+            'session_event_type': FRAUD_SESSION_EVENT_TYPE,
+            'pid': PID,
+            'request_id': REQUEST_ID,
+            'idp_entity_id': IDP_ENTITY_ID,
+            'idp_fraud_event_id': fraud_event_id,
+            'gpg45_status': GPG45_STATUS,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID
+        }
+    })
+
+
+def create_fraud_event_without_idp_fraud_event_id_string(event_id, session_id):
+    return json.dumps({
+        'eventId': event_id,
+        'eventType': EVENT_TYPE,
+        'timestamp': TIMESTAMP,
+        'originatingService': ORIGINATING_SERVICE,
+        'sessionId': session_id,
+        'details': {
+            'session_event_type': FRAUD_SESSION_EVENT_TYPE,
+            'pid': PID,
+            'request_id': REQUEST_ID,
+            'idp_entity_id': IDP_ENTITY_ID,
+            'gpg45_status': GPG45_STATUS,
+            'transaction_entity_id': TRANSACTION_ENTITY_ID
+        }
+    })

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,5 +1,7 @@
 import json
 import os
+import boto3
+import botocore.exceptions
 from src.database import RunInTransaction
 
 EVENT_TYPE = 'session_event'
@@ -114,3 +116,15 @@ def create_fraud_event_without_idp_fraud_event_id_string(event_id, session_id):
             'transaction_entity_id': TRANSACTION_ENTITY_ID
         }
     })
+
+
+def file_exists_in_s3(bucket_name, key):
+    s3 = boto3.resource('s3')
+    try:
+        s3.Object(bucket_name, key).load()
+        return True
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == "404":
+            return False
+        else:
+            raise

--- a/test/idp_fraud_data_handler_test.py
+++ b/test/idp_fraud_data_handler_test.py
@@ -70,29 +70,29 @@ class IdpFraudDataHandlerTest(TestCase):
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[0].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[1].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[2].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[3].idp_event_id
                     )
                 ),
@@ -104,72 +104,6 @@ class IdpFraudDataHandlerTest(TestCase):
             )
             self.__assert_upload_session_exists_in_database(True)
             self.__assert_events_exist_in_database(idp_fraud_events)
-            self.__assert_upload_file_has_been_moved_to_folder(idp_fraud_data_handler.SUCCESS_FOLDER)
-
-    def test_writes_messages_to_db_matches_to_existing_fraud_data(self):
-        event_id_1 = str(uuid.uuid4())
-        event_id_2 = str(uuid.uuid4())
-        fraud_events = [
-            event_mapper.event_from_json(create_fraud_event_string(event_id_1, 'session-id-1', '1111111')),
-            event_mapper.event_from_json(create_fraud_event_string(event_id_2, 'session-id-2', '2222222')),
-        ]
-        for event in fraud_events:
-            database.write_audit_event_to_database(event, self.db_connection)
-            database.write_fraud_event_to_database(event, self.db_connection)
-
-        idp_fraud_events = self.__generate_test_idp_fraud_events()
-        self.__write_import_file_to_s3(idp_fraud_events)
-
-        with LogCapture('idp_fraud_data_handler', propagate=False) as log_capture:
-            idp_fraud_data_handler.idp_fraud_data_events(self.__create_s3_event(), None)
-
-            log_capture.check(
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Created connection to DB'
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Processing data for IDP {}'.format(IDP_ENTITY_ID)
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Successfully wrote IDP fraud event ID {} to database and found matching fraud event {}'.format(
-                        idp_fraud_events[0].idp_event_id, event_id_1
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Successfully wrote IDP fraud event ID {} to database and found matching fraud event {}'.format(
-                        idp_fraud_events[1].idp_event_id, event_id_2
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[2].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[3].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Processing successful'
-                )
-            )
-            self.__assert_upload_session_exists_in_database(True)
-            self.__assert_events_exist_in_database(idp_fraud_events, fraud_events)
             self.__assert_upload_file_has_been_moved_to_folder(idp_fraud_data_handler.SUCCESS_FOLDER)
 
     def test_writes_messages_to_db_and_increments_contra_indicator_count_correctly(self):
@@ -227,22 +161,22 @@ class IdpFraudDataHandlerTest(TestCase):
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[0].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[1].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[2].idp_event_id
                     )
                 ),
@@ -254,157 +188,6 @@ class IdpFraudDataHandlerTest(TestCase):
             )
             self.__assert_upload_session_exists_in_database(True)
             self.__assert_events_exist_in_database(idp_fraud_events)
-            self.__assert_upload_file_has_been_moved_to_folder(idp_fraud_data_handler.SUCCESS_FOLDER)
-
-    def test_writes_messages_to_db_and_handles_duplicate_event_ids_correctly(self):
-        pid1 = str(uuid.uuid4())
-        pid2 = str(uuid.uuid4())
-        request_id_1 = "_{}".format(uuid.uuid4())
-        request_id_2 = "_{}".format(uuid.uuid4())
-        idp_fraud_events = [
-            IdpFraudEvent(
-                timestamp="05/08/2019 11:54",
-                idp_event_id="1111111",
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code="DF01",
-                contra_indicators=["A04", "D02"],
-                contra_score=-5,
-                request_id=request_id_1,
-                client_ip_address="111.222.222.111",
-                pid=pid1
-            ),
-            IdpFraudEvent(
-                timestamp="05/08/2019 11:54",
-                idp_event_id="1111111",
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code="DF01",
-                contra_indicators=["A01", "D15", "A01"],
-                contra_score=-5,
-                request_id=request_id_1,
-                client_ip_address="111.222.222.111",
-                pid=pid1
-            ),
-            IdpFraudEvent(
-                timestamp="10/08/2019 09:24",
-                idp_event_id="3333333",
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code="DF01",
-                contra_indicators=["A01", "A05", "V03"],
-                contra_score=-10,
-                request_id=request_id_2,
-                client_ip_address="111.111.111.111",
-                pid=pid2
-            ),
-            IdpFraudEvent(
-                timestamp="10/08/2019 09:24",
-                idp_event_id="3333333",
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code="DF01",
-                contra_indicators=["A01"],
-                contra_score=-5,
-                request_id=request_id_2,
-                client_ip_address="111.111.111.111",
-                pid=pid2
-            ),
-            IdpFraudEvent(
-                timestamp="10/08/2019 09:24",
-                idp_event_id="3333333",
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code="DF01",
-                contra_indicators=["A06"],
-                contra_score=-7,
-                request_id=request_id_2,
-                client_ip_address="111.111.111.111",
-                pid=pid2
-            ),
-        ]
-
-        aggregated_events = [
-            IdpFraudEvent(
-                timestamp=idp_fraud_events[0].timestamp,
-                idp_event_id=idp_fraud_events[0].idp_event_id,
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code=idp_fraud_events[0].fid_code,
-                contra_indicators=idp_fraud_events[0].contra_indicators + idp_fraud_events[1].contra_indicators,
-                contra_score=idp_fraud_events[0].contra_score + idp_fraud_events[1].contra_score,
-                request_id=idp_fraud_events[0].request_id,
-                client_ip_address=idp_fraud_events[0].client_ip_address,
-                pid=idp_fraud_events[0].pid
-            ),
-            IdpFraudEvent(
-                timestamp=idp_fraud_events[2].timestamp,
-                idp_event_id=idp_fraud_events[2].idp_event_id,
-                idp_entity_id=IDP_ENTITY_ID,
-                fid_code=idp_fraud_events[2].fid_code,
-                contra_indicators=idp_fraud_events[2].contra_indicators + idp_fraud_events[3].contra_indicators
-                                                                        + idp_fraud_events[4].contra_indicators,
-                contra_score=idp_fraud_events[2].contra_score + idp_fraud_events[3].contra_score
-                                                              + idp_fraud_events[4].contra_score,
-                request_id=idp_fraud_events[2].request_id,
-                client_ip_address=idp_fraud_events[2].client_ip_address,
-                pid=idp_fraud_events[2].pid
-            ),
-        ]
-
-        self.__write_import_file_to_s3(idp_fraud_events)
-
-        with LogCapture('idp_fraud_data_handler', propagate=False) as log_capture:
-            idp_fraud_data_handler.idp_fraud_data_events(self.__create_s3_event(), None)
-
-            log_capture.check(
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Created connection to DB'
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Processing data for IDP {}'.format(IDP_ENTITY_ID)
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[0].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[1].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[2].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[3].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
-                        idp_fraud_events[4].idp_event_id
-                    )
-                ),
-                (
-                    'idp_fraud_data_handler',
-                    'INFO',
-                    'Processing successful'
-                )
-            )
-            self.__assert_upload_session_exists_in_database(True)
-            self.__assert_events_exist_in_database(aggregated_events)
             self.__assert_upload_file_has_been_moved_to_folder(idp_fraud_data_handler.SUCCESS_FOLDER)
 
     def test_invalid_data_causes_error(self):
@@ -429,29 +212,29 @@ class IdpFraudDataHandlerTest(TestCase):
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[0].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[1].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[2].idp_event_id
                     )
                 ),
                 (
                     'idp_fraud_data_handler',
-                    'WARNING',
-                    'Successfully wrote IDP fraud event ID {} to database BUT no matching fraud event found'.format(
+                    'INFO',
+                    'Successfully wrote IDP fraud event ID {} to database.'.format(
                         idp_fraud_events[3].idp_event_id
                     )
                 ),
@@ -611,7 +394,7 @@ class IdpFraudDataHandlerTest(TestCase):
             self.assertEqual(result[3], field)
             self.assertEqual(result[4], message)
 
-    def __assert_events_exist_in_database(self, idp_fraud_events, fraud_events=None):
+    def __assert_events_exist_in_database(self, idp_fraud_events):
         with RunInTransaction(self.db_connection) as cursor:
             for event in idp_fraud_events:
                 cursor.execute("""
@@ -625,7 +408,6 @@ class IdpFraudDataHandlerTest(TestCase):
                         a.pid,
                         a.client_ip_address,
                         a.contra_score,
-                        a.event_id,
                         a.upload_session_id,
                         b.source_file_name
                       FROM idp_data.idp_fraud_events a
@@ -647,17 +429,8 @@ class IdpFraudDataHandlerTest(TestCase):
                 self.assertEqual(result[6], event.pid)
                 self.assertEqual(result[7], event.client_ip_address)
                 self.assertEqual(result[8], event.contra_score)
-                self.assertIsNotNone(result[10])
-                self.assertEqual(result[11], UPLOAD_FILE_NAME)
-
-                if fraud_events is not None:
-                    event_id = None
-                    matched_fraud_events = \
-                        [e for e in fraud_events if e.details['idp_fraud_event_id'] == event.idp_event_id
-                         and e.details['idp_entity_id'] == event.idp_entity_id]
-                    if matched_fraud_events:
-                        event_id = matched_fraud_events[0].event_id
-                    self.assertEqual(result[9], event_id)
+                self.assertIsNotNone(result[9])
+                self.assertEqual(result[10], UPLOAD_FILE_NAME)
 
                 if event.contra_indicators:
                     contra_indicators = list(set(event.contra_indicators))
@@ -692,7 +465,6 @@ class IdpFraudDataHandlerTest(TestCase):
                         a.pid,
                         a.client_ip_address,
                         a.contra_score,
-                        a.event_id,
                         a.upload_session_id,
                         b.source_file_name
                       FROM idp_data.idp_fraud_events a

--- a/test/idp_fraud_data_handler_test.py
+++ b/test/idp_fraud_data_handler_test.py
@@ -1,0 +1,205 @@
+import os
+import boto3
+import psycopg2
+import urllib.parse
+import uuid
+
+from moto import mock_s3
+from unittest import TestCase
+from datetime import datetime
+from testfixtures import LogCapture
+from retrying import retry
+
+from src import idp_fraud_data_handler
+from src.idp_fraud_event import IdpFraudEvent
+from src.database import RunInTransaction
+
+IMPORT_BUCKET_NAME = 's3-idp-fraud-data-bucket'
+IMPORT_FILE_NAME = 'idp-data.csv'
+UPLOAD_USERNAME = 'my.user.name@example.com'
+VALID_ENTITY_ID = 'http://my.example.com/idp/SAML'
+DB_PASSWORD = 'secretPassword'
+
+
+@mock_s3
+class IdpFraudDataHandlerTest(TestCase):
+    __s3_client = None
+    __kms_client = None
+    __queue_url = None
+    __key_id = None
+    db_connection = None
+    db_connection_string = "host='event-store' dbname='events' user='postgres'"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.connect()
+
+    @classmethod
+    @retry(stop_max_attempt_number=5, wait_fixed=500)
+    def connect(cls):
+        cls.db_connection = psycopg2.connect(cls.db_connection_string)
+
+    def setUp(self):
+        self.__setup_stub_aws_config()
+        self.__setup_s3()
+        self.__setup_db_connection_string()
+
+    def tearDown(self):
+        self.__clean_db()
+
+    def test_writes_messages_to_db(self):
+        idp_fraud_events = [
+            IdpFraudEvent(
+                timestamp="05/08/2019 11:54",
+                idp_event_id="1111111",
+                idp_entity_id=VALID_ENTITY_ID,
+                fid_code="DF01",
+                contra_indicators=["A04", "D02"],
+                contra_score=-5,
+                request_id="_{}".format(uuid.uuid4()),
+                client_ip_address="111.222.222.111",
+                pid=uuid.uuid4()
+            ),
+            IdpFraudEvent(
+                timestamp="07/08/2019 16:37",
+                idp_event_id="2222222",
+                idp_entity_id=VALID_ENTITY_ID,
+                fid_code="DF01",
+                contra_indicators=["ROLB", "D15"],
+                contra_score=-5,
+                request_id="_{}".format(uuid.uuid4()),
+                client_ip_address="222.111.111.222",
+                pid=uuid.uuid4()
+            ),
+            IdpFraudEvent(
+                timestamp="10/08/2019 09:24",
+                idp_event_id="3333333",
+                idp_entity_id=VALID_ENTITY_ID,
+                fid_code="DF01",
+                contra_indicators=["A01", "A05", "V03"],
+                contra_score=-10,
+                request_id="_{}".format(uuid.uuid4()),
+                client_ip_address="111.111.111.111",
+                pid=uuid.uuid4()
+            ),
+            IdpFraudEvent(
+                timestamp="23/08/2019 21:22",
+                idp_event_id="4444444",
+                idp_entity_id=VALID_ENTITY_ID,
+                fid_code="DF01",
+                contra_indicators=["D02"],
+                contra_score=-4,
+                request_id="_{}".format(uuid.uuid4()),
+                client_ip_address="222.222.222.222",
+                pid=uuid.uuid4()
+            ),
+        ]
+        self.__write_import_file_to_s3(idp_fraud_events)
+
+        with LogCapture('idp_fraud_data_handler', propagate=False) as log_capture:
+            idp_fraud_data_handler.idp_fraud_data_events(self.__create_s3_event(), None)
+
+            log_capture.check(
+                (
+                    'idp_fraud_data_handler',
+                    'INFO',
+                    'Created connection to DB'
+                ),
+            )
+            self.__assert_upload_session_exists_in_database(False)
+            self.__assert_import_file_has_been_removed_from_s3()
+
+    def __clean_db(self):
+        with RunInTransaction(self.db_connection) as cursor:
+            cursor.execute("""
+                DELETE FROM idp_data.idp_fraud_event_contraindicators;
+                DELETE FROM idp_data.idp_fraud_events;
+                DELETE FROM idp_data.upload_session_validation_failures;
+                DELETE FROM idp_data.upload_sessions;
+            """)
+
+    def __assert_import_file_has_been_removed_from_s3(self):
+        s3 = boto3.resource('s3')
+        bucket = s3.Bucket(IMPORT_BUCKET_NAME)
+        self.assertEqual(len(list(bucket.objects.all())), 0)
+
+    def __assert_upload_session_exists_in_database(self, passed_validation):
+        with RunInTransaction(self.db_connection) as cursor:
+            cursor.execute("""
+                SELECT 
+                    id,
+                    source_file_name,
+                    idp_entity_id,
+                    userid,
+                    passed_validation
+                  FROM idp_data.upload_sessions
+            """)
+            result = cursor.fetchone()
+
+        self.assertIsNotNone(result)
+        self.assertIsNotNone(result[0])
+        self.assertEqual(result[1], IMPORT_FILE_NAME)
+        self.assertEqual(result[2], VALID_ENTITY_ID)
+        self.assertEqual(result[3], UPLOAD_USERNAME)
+        self.assertEqual(result[4], passed_validation)
+
+    def __setup_db_connection_string(self):
+        os.environ['DB_CONNECTION_STRING'] = "{} password='{}'".format(self.db_connection_string, DB_PASSWORD)
+
+    def __setup_s3(self):
+        self.__s3_client = boto3.client('s3')
+        self.__s3_client.create_bucket(
+            Bucket=IMPORT_BUCKET_NAME,
+        )
+
+    def __write_import_file_to_s3(self, idp_fraud_events):
+        rows = ['FID_Event_Time, EVENT_ID, FID_code, contraindicators_raised, Contra_score, Authentication_ID, Client_IPAddress, PID']
+        rows = rows + [self.__idp_fraud_event_to_csv_string(event) for event in idp_fraud_events]
+        self.__write_to_s3(IMPORT_BUCKET_NAME, IMPORT_FILE_NAME, '\n'.join(rows))
+
+    def __write_to_s3(self, bucket_name, filename, content):
+        tags = {
+            'username': UPLOAD_USERNAME,
+            'idp': VALID_ENTITY_ID,
+        }
+        self.__s3_client.put_object(
+            Bucket=bucket_name,
+            Key=filename,
+            Body=content,
+            Tagging=urllib.parse.urlencode(tags)
+        )
+
+    def __setup_stub_aws_config(self):
+        os.environ = {
+            'AWS_DEFAULT_REGION': 'eu-west-2',
+            'AWS_ACCESS_KEY_ID': 'AWS_ACCESS_KEY_ID',
+            'AWS_SECRET_ACCESS_KEY': 'AWS_SECRET_ACCESS_KEY'
+        }
+
+    def __create_s3_event(self):
+        return {
+            "Records": [
+                {
+                    "s3": {
+                        "bucket": {
+                            "name": IMPORT_BUCKET_NAME,
+                        },
+                        "object": {
+                            "key": IMPORT_FILE_NAME,
+                        }
+                    }
+                }
+            ]
+        }
+
+    def __idp_fraud_event_to_csv_string(self, idp_fraud_event):
+        return '"{}","{}","{}","{}",{},"{}","{}","{}"'.format(
+            idp_fraud_event.timestamp,
+            idp_fraud_event.idp_event_id,
+            idp_fraud_event.fid_code,
+            ','.join(idp_fraud_event.contra_indicators),
+            idp_fraud_event.contra_score,
+            idp_fraud_event.request_id,
+            idp_fraud_event.client_ip_address,
+            idp_fraud_event.pid
+        )

--- a/test/idp_fraud_data_handler_test.py
+++ b/test/idp_fraud_data_handler_test.py
@@ -14,7 +14,7 @@ from testfixtures import LogCapture
 from src import idp_fraud_data_handler, database, event_mapper
 from src.database import RunInTransaction
 from src.idp_fraud_event import IdpFraudEvent
-from test.helpers import IDP_ENTITY_ID, clean_db, create_fraud_event_string, file_exists_in_s3, setup_stub_aws_config, \
+from test.helpers import IDP_ENTITY_ID, clean_db, file_exists_in_s3, setup_stub_aws_config, \
     DB_PASSWORD
 
 UPLOAD_BUCKET_NAME = 's3-idp-fraud-data-bucket'
@@ -42,7 +42,7 @@ class IdpFraudDataHandlerTest(TestCase):
         cls.db_connection = psycopg2.connect(cls.db_connection_string)
 
     def setUp(self):
-        setup_stub_aws_config
+        setup_stub_aws_config()
         self.__setup_s3()
         self.__setup_db_connection_string()
 


### PR DESCRIPTION
# What

We now have an S3 bucket to which members of the fraud team can write files. We now need to process these files.

We will write a lamda that runs when file is uploaded to bucket (triggered by a Cloudwatch event).

We should validate the file and throw appropriate errors

In this card we should handle the success cases correctly, we will handle validation in and what to do with error cases in a different card.

## How

Add `idp_fraud_data_handler` and test
Add logic to process incoming event and create an upload session record in database
Persist data in `idp_data.idp_fraud_events`
Persist contra indicators in  in `idp_data.idp_fraud_event_contraindicators`
Refactor tests to share 'helper' methods
Add matching of events to data in `billing.fraud_events`
Add basic error handling
Move upload file to success or error folder depending on result
Update session information to indicate pass validation
Refactor shared code
Add basic writing of errors to database (no validation yet)