### PR TITLE
ps34 Record new preferred LOA billing information

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -70,7 +70,7 @@ def write_billing_event_to_database(event, db_connection):
                     request_id,
                     idp_entity_id,
                     minimum_level_of_assurance,
-                    required_level_of_assurance,
+                    preferred_level_of_assurance,
                     provided_level_of_assurance,
                     event_id,
                     transaction_entity_id
@@ -84,7 +84,7 @@ def write_billing_event_to_database(event, db_connection):
                 event.details['request_id'],
                 event.details['idp_entity_id'],
                 event.details['minimum_level_of_assurance'],
-                event.details['required_level_of_assurance'],
+                event.details['preferred_level_of_assurance'],
                 event.details['provided_level_of_assurance'],
                 event.event_id,
                 event.details['transaction_entity_id']

--- a/test/event_handler_test.py
+++ b/test/event_handler_test.py
@@ -16,7 +16,7 @@ from test.helpers import setup_stub_aws_config, clean_db, create_event_string, c
     MINIMUM_LEVEL_OF_ASSURANCE, ENCRYPTION_KEY, create_billing_event_without_minimum_level_of_assurance_string, \
     create_fraud_event_without_idp_fraud_event_id_string, EVENT_TYPE, TIMESTAMP, ORIGINATING_SERVICE, \
     SESSION_EVENT_TYPE, TRANSACTION_ENTITY_ID, FRAUD_SESSION_EVENT_TYPE, DB_PASSWORD, \
-    PID, REQUEST_ID, IDP_ENTITY_ID, PROVIDED_LEVEL_OF_ASSURANCE, REQUIRED_LEVEL_OF_ASSURANCE, GPG45_STATUS
+    PID, REQUEST_ID, IDP_ENTITY_ID, PROVIDED_LEVEL_OF_ASSURANCE, PREFERRED_LEVEL_OF_ASSURANCE, GPG45_STATUS
 from test.test_encrypter import encrypt_string
 
 
@@ -301,7 +301,7 @@ class EventHandlerTest(TestCase):
                         details->>'transaction_entity_id',
                         details->>'minimum_level_of_assurance',
                         details->>'provided_level_of_assurance',
-                        details->>'required_level_of_assurance'
+                        details->>'preferred_level_of_assurance'
                     FROM
                         audit.audit_events
                     WHERE
@@ -322,7 +322,7 @@ class EventHandlerTest(TestCase):
             self.assertEqual(matching_records[9], TRANSACTION_ENTITY_ID)
             self.assertEqual(matching_records[10], minimum_level_of_assurance)
             self.assertEqual(matching_records[11], PROVIDED_LEVEL_OF_ASSURANCE)
-            self.assertEqual(matching_records[12], REQUIRED_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[12], PREFERRED_LEVEL_OF_ASSURANCE)
 
     def __assert_audit_events_table_has_fraud_event_records(self, expected_events):
         for event in expected_events:
@@ -383,7 +383,7 @@ class EventHandlerTest(TestCase):
                         request_id,
                         idp_entity_id,
                         minimum_level_of_assurance,
-                        required_level_of_assurance,
+                        preferred_level_of_assurance,
                         provided_level_of_assurance,
                         event_id,
                         transaction_entity_id
@@ -402,7 +402,7 @@ class EventHandlerTest(TestCase):
             self.assertEqual(matching_records[4], IDP_ENTITY_ID)
             self.assertEqual(matching_records[5], MINIMUM_LEVEL_OF_ASSURANCE)
             self.assertEqual(matching_records[6], PROVIDED_LEVEL_OF_ASSURANCE)
-            self.assertEqual(matching_records[7], REQUIRED_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[7], PREFERRED_LEVEL_OF_ASSURANCE)
             self.assertEqual(matching_records[8], event_id)
             self.assertEqual(matching_records[9], TRANSACTION_ENTITY_ID)
 

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -16,7 +16,7 @@ IDP_ENTITY_ID = 'idp entity id'
 TRANSACTION_ENTITY_ID = 'transaction entity id'
 MINIMUM_LEVEL_OF_ASSURANCE = 'LEVEL_2'
 PROVIDED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
-REQUIRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+PREFERRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
 FRAUD_SESSION_EVENT_TYPE = 'fraud_detected'
 GPG45_STATUS = 'AA01'
 
@@ -57,7 +57,7 @@ def create_event_string(event_id, session_id):
             'transaction_entity_id': TRANSACTION_ENTITY_ID,
             'minimum_level_of_assurance': MINIMUM_LEVEL_OF_ASSURANCE,
             'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
-            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
+            'preferred_level_of_assurance': PREFERRED_LEVEL_OF_ASSURANCE
         }
     })
 
@@ -76,7 +76,7 @@ def create_billing_event_without_minimum_level_of_assurance_string(event_id, ses
             'idp_entity_id': IDP_ENTITY_ID,
             'transaction_entity_id': TRANSACTION_ENTITY_ID,
             'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
-            'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
+            'preferred_level_of_assurance': PREFERRED_LEVEL_OF_ASSURANCE
         }
     })
 

--- a/test/import_handler_test.py
+++ b/test/import_handler_test.py
@@ -26,7 +26,7 @@ IDP_ENTITY_ID = 'idp entity id'
 TRANSACTION_ENTITY_ID = 'transaction entity id'
 MINIMUM_LEVEL_OF_ASSURANCE = 'LEVEL_2'
 PROVIDED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
-REQUIRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
+PREFERRED_LEVEL_OF_ASSURANCE = 'LEVEL_2'
 FRAUD_SESSION_EVENT_TYPE = 'fraud_detected'
 GPG45_STATUS = 'AA01'
 IMPORT_BUCKET_NAME = 's3-import-bucket'
@@ -150,7 +150,7 @@ class ImportHandlerTest(TestCase):
                         details->>'transaction_entity_id',
                         details->>'minimum_level_of_assurance',
                         details->>'provided_level_of_assurance',
-                        details->>'required_level_of_assurance'
+                        details->>'preferred_level_of_assurance'
                     FROM
                         audit.audit_events
                     WHERE
@@ -171,7 +171,7 @@ class ImportHandlerTest(TestCase):
             self.assertEqual(matching_records[9], TRANSACTION_ENTITY_ID)
             self.assertEqual(matching_records[10], minimum_level_of_assurance)
             self.assertEqual(matching_records[11], PROVIDED_LEVEL_OF_ASSURANCE)
-            self.assertEqual(matching_records[12], REQUIRED_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[12], PREFERRED_LEVEL_OF_ASSURANCE)
 
     def __assert_audit_events_table_has_fraud_event_records(self, expected_events):
         for event in expected_events:
@@ -220,7 +220,7 @@ class ImportHandlerTest(TestCase):
                         request_id,
                         idp_entity_id,
                         minimum_level_of_assurance,
-                        required_level_of_assurance,
+                        preferred_level_of_assurance,
                         provided_level_of_assurance
                     FROM
                         billing.billing_events
@@ -238,7 +238,7 @@ class ImportHandlerTest(TestCase):
             self.assertEqual(matching_records[4], IDP_ENTITY_ID)
             self.assertEqual(matching_records[5], MINIMUM_LEVEL_OF_ASSURANCE)
             self.assertEqual(matching_records[6], PROVIDED_LEVEL_OF_ASSURANCE)
-            self.assertEqual(matching_records[7], REQUIRED_LEVEL_OF_ASSURANCE)
+            self.assertEqual(matching_records[7], PREFERRED_LEVEL_OF_ASSURANCE)
 
     def __assert_fraud_events_table_has_fraud_event_records(self, expected_fraud_events):
         for fraud_event in expected_fraud_events:
@@ -351,7 +351,7 @@ class ImportHandlerTest(TestCase):
                     'transaction_entity_id': TRANSACTION_ENTITY_ID,
                     'minimum_level_of_assurance': MINIMUM_LEVEL_OF_ASSURANCE,
                     'provided_level_of_assurance': PROVIDED_LEVEL_OF_ASSURANCE,
-                    'required_level_of_assurance': REQUIRED_LEVEL_OF_ASSURANCE
+                    'preferred_level_of_assurance': PREFERRED_LEVEL_OF_ASSURANCE
                 }
             }
         })


### PR DESCRIPTION
This PR is one part of several across Verify to be able to support billing for new special case `LOA2,LOA1/exact` requests. The columns for the `billing_events` table change in a migration (see [verify-event-system-database-scripts#48](https://github.com/alphagov/verify-event-system-database-scripts/pull/48)), adding a new `preferred_level_of_assurance` column. Required LOA information is now deprecated.

Changes in this PR:

* Record new `preferred_level_of_assurance` information.
* Do not record `required_level_of_assurance` (now deprecated).

The full set of changes being made is laid out in:

* [ADR 36 billing changes plan](https://docs.google.com/document/d/1hblVU0wquj6Z3-b9V75z6jb1wt3Nnpjh2MNHxNGgTBE/edit?usp=sharing)

For context, please see:

* [ADR 35](https://github.com/alphagov/verify-architecture/blob/master/adr/0035-allow-specified-loa2-services-to-receive-loa1-identities.md) (sending LOA2,LOA1/exact requests to IDPs)
* [ADR 36](https://github.com/alphagov/verify-architecture/blob/master/adr/0036-support-billing-on-provided-loa.md) (changes to support billing for the new requests)