### PR TITLE
Update write_billing_event_to_database

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -60,6 +60,9 @@ def write_audit_event_to_database(event, db_connection):
 
 def write_billing_event_to_database(event, db_connection):
     try:
+        preferred_LOA = event.details['preferred_level_of_assurance'] if 'preferred_level_of_assurance' in event.details else None
+        required_LOA = event.details['required_level_of_assurance'] if 'required_level_of_assurance' in event.details else None
+
         with RunInTransaction(db_connection) as cursor:
             cursor.execute("""
                 INSERT INTO billing.billing_events
@@ -71,12 +74,13 @@ def write_billing_event_to_database(event, db_connection):
                     idp_entity_id,
                     minimum_level_of_assurance,
                     preferred_level_of_assurance,
+                    required_level_of_assurance,
                     provided_level_of_assurance,
                     event_id,
                     transaction_entity_id
                 )
                 VALUES
-                (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
+                (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s);
             """, [
                 datetime.fromtimestamp(int(event.timestamp) / 1e3),
                 event.session_id,
@@ -84,7 +88,8 @@ def write_billing_event_to_database(event, db_connection):
                 event.details['request_id'],
                 event.details['idp_entity_id'],
                 event.details['minimum_level_of_assurance'],
-                event.details['preferred_level_of_assurance'],
+                preferred_LOA,
+                required_LOA,
                 event.details['provided_level_of_assurance'],
                 event.event_id,
                 event.details['transaction_entity_id']


### PR DESCRIPTION
* Not all events to be recorded have `preferred_level_of_assurance` set.
* Retain ability to record events with `required_level_of_assurance` where present.