### PR TITLE
Audit events to splunk

### DIFF
--- a/build/run-tests.sh
+++ b/build/run-tests.sh
@@ -3,7 +3,7 @@ set -e
 
 SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 
-function stop_containers() {
+stop_containers() {
   docker-compose down
 }
 

--- a/src/event_handler.py
+++ b/src/event_handler.py
@@ -50,6 +50,12 @@ def store_queued_events(_, __):
         try:
             decrypted_message = decrypt_message(message['Body'], decryption_key)
             event = event_from_json(decrypted_message)
+
+            # Send audit events to this lambda function's CloudWatch log group.
+            # This is the raw JSON event on a line by its self so Splunk can
+            # parse it as JSON.
+            print(decrypted_message)
+
             logger.info('Decrypted event with ID: {0}'.format(event.event_id))
             write_audit_event_to_database(event, db_connection)
             logger.info('Stored audit event: {0}'.format(event.event_id))


### PR DESCRIPTION
I've added the implicit lambda log group to terraform. This will need to be imported into the Terraform state manually. The log group is then subscribed to the CSLS Kinesis endpoint. This will send all event-recorder lambda output to Splunk.