### PR TITLE
BAU - Fix event recording lambdas

### DIFF
--- a/package.Dockerfile
+++ b/package.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6 as install
+FROM python:3.7 as install
 
 WORKDIR /install
 COPY requirements/ requirements/
@@ -6,11 +6,11 @@ RUN python3 -m pip install -r requirements/prod.txt
 
 COPY src src
 
-FROM alpine:3.8 as package
+FROM alpine:3.16 as package
 
 RUN apk add zip
 WORKDIR /package
-COPY --from=install /usr/local/lib/python3.6/site-packages/ .
+COPY --from=install /usr/local/lib/python3.7/site-packages/ .
 COPY --from=install /install/src/ src/
 
 CMD ["zip", "-qr", "verify-event-recorder-service.zip", "."]

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -1,3 +1,3 @@
-psycopg2-binary==2.7.4
+psycopg2-binary==2.8.3
 cryptography==2.3.1
 dateparser==0.7.2


### PR DESCRIPTION
- We are seeing errors in the lambdas such as No module named 'psycopg2._psycopg'.
- Bump the alpine to 3.16
- Bump python version to 3.7. AWS Lambda no longer supports 3.6
- Bump psycopg2-binary to 2.8.3